### PR TITLE
consolidate author info and use update-copyright.py to generate AUTHORS

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,4 @@
+Edmund Hart <edmund.m.hart@gmail.com> <edmund_hart@apple.com> <edmund.m.hart@gmail.com>
+markrobinsonuzh <markrobinsonuzh@users.noreply.github.com> <mark.robinson@imls.uzh.ch>
+Tracy Teal <tkteal@gmail.com> <tracyt@idyll.org>
+Francois Michonneau <francois.michonneau@gmail.com> <francois.michonneau@gmail.Com>

--- a/.update-copyright.conf
+++ b/.update-copyright.conf
@@ -1,0 +1,6 @@
+[project]
+vcs: Git
+
+[files]
+authors: yes
+files: no

--- a/04-dplyr.Rmd
+++ b/04-dplyr.Rmd
@@ -266,5 +266,3 @@ res <- surveys %>%
 --->
 
 [Handy dplyr cheatsheet](http://www.rstudio.com/wp-content/uploads/2015/02/data-wrangling-cheatsheet.pdf)
-
-*Much of this lesson was copied or adapted from Jeff Hollister's [materials](http://usepa.github.io/introR/2015/01/14/03-Clean/)*

--- a/05-visualization-ggplot2.Rmd
+++ b/05-visualization-ggplot2.Rmd
@@ -13,10 +13,6 @@ knitr::opts_chunk$set(fig.keep='last')
 source("setup.R")
 ```
 
-Authors: **Mateusz Kuzak**, **Diana Marek**, **Hedi Peterson**
-
-
-
 #### Disclaimer
 
 We will be using the functions in the ggplot2 package. There are basic plotting

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,38 @@
+R-ecology was written by:
+Adam Obeng <github@binaryeagle.com>
+Aleksandra Pawlik <aleksandra.n.pawlik@gmail.com>
+Ben Marwick <benmarwick@hotmail.com>
+C. Titus Brown <titus@idyll.org>
+Earle Wilson <ewilson2011@gmail.com>
+Edmund Hart <edmund.m.hart@gmail.com>
+Elena Sügis <elena.sugis@gmail.com>
+Emilia Gan <efgan@uw.edu>
+Ethan White <ethan@weecology.org>
+Francois Michonneau <francois.michonneau@gmail.Com>
+Harriet Dashnow <h.dashnow@gmail.com>
+Hilmar Lapp <hlapp@drycafe.net>
+Josh Herr <joshua.r.herr@gmail.com>
+KWHall <KWHall@MSU.edu>
+Kara Woo <woo.kara@gmail.com>
+Karthik Ram <karthik.ram@gmail.com>
+Kyriakos Chatzidimitriou <kyrcha@gmail.com>
+Laurent <lg390@cam.ac.uk>
+Leah Wasser <lwasser@neoninc.org>
+Leszek Tarkowski <leszek@czterybity.pl>
+Mateusz Kuzak <mateusz.kuzak@gmail.com>
+Michael Koontz <mikoontz@gmail.com>
+Philip Lijnzaad <philip.lijnzaad@gmail.com>
+Steve Pederson <stephen.pederson.au@gmail.com>
+Ted Hart <edmund.m.hart@gmail.com>
+Tracy Teal <tkteal@gmail.com>
+Will Furnass <will@thearete.co.uk>
+cbahlai <cbahlai@msu.edu>
+duffymeg <duffy.ma@gmail.com>
+fishman <dmytrofishman@gmail.com>
+jsta <jstachelek@utexas.edu>
+kcranston <karen.cranston@gmail.com>
+markrobinsonuzh <markrobinsonuzh@users.noreply.github.com>
+mkuzak <mateusz.kuzak@gmail.com>
+plijnzaad <plijnzaad@users.noreply.github.com>
+sarahsupp <sarah@weecology.org>
+suparee <suparee@uw.edu>

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -7,8 +7,6 @@ White and contributions from Deb Paul and Mike Smorul.
 
 ## Data
 
-### Biology
-
 Data is from the paper S. K. Morgan Ernest, Thomas J. Valone, and James
 H. Brown. 2009. Long-term monitoring and experimental manipulation of a
 Chihuahuan Desert ecosystem near Portal, Arizona, USA. Ecology 90:1708.
@@ -18,9 +16,18 @@ http://esapubs.org/archive/ecol/E090/118/
 A simplified version of this data, suitable for teaching is available on
 [figshare](https://dx.doi.org/10.6084/m9.figshare.1314459.v5).
 
-### R materials
+## Lessons
 
-Original materials adapted from SWC Python lessons by Sarah Supp.  John Blischak
+Original materials adapted from SWC Python lessons by Sarah Supp. John Blischak
 led the continued development of materials with contributions from Gavin
 Simpson, Tracy Teal, Greg Wilson, Diego Barneche, Stephen Turner and Karthik
-Ram. This original material has been modified and expanded by Francois Michonneau.
+Ram. This original material has been modified and expanded by Francois
+Michonneau.
+
+The dplyr lesson was created by Kara Woo, who copied and modified and modified
+from Jeff Hollister's
+[materials](http://usepa.github.io/introR/2015/01/14/03-Clean/).
+
+The ggplot2 lesson was initially created by Mateusz Kuzak, Diana Marek, and Hedi
+Peterson, during a Hackathon in Espoo, Finland on March 16-17, 2015, sponsored
+by the [ELIXIR project](http://elixir-europe.org/).


### PR DESCRIPTION
This is an example of what was discussed in datacarpentry/lesson-template#22 and could be generalized to other lessons. The AUTHORS file is generated automatically by the [update-copyright python package](https://pypi.python.org/pypi/update-copyright/) but the script needs to be run manually. Currently, SWC runs the script before major releases of the lessons. Here, it could be added to the Makefile, but it would require that the package is installed for it to work.