### PR TITLE
Fix some typos

### DIFF
--- a/01-intro-to-R.Rmd
+++ b/01-intro-to-R.Rmd
@@ -294,7 +294,7 @@ weight_g[weight_g >= 30 & weight_g == 21]
 
 When working with vectors of characters, if you are trying to combine many
 conditions it can become tedious to type. The function `%in%` allows you to test
-if a value if found in a vector:
+if a value is found in a vector:
 
 ```{r, results='show', purl=FALSE}
 animals <- c("mouse", "rat", "dog", "cat")

--- a/03-data-frames.Rmd
+++ b/03-data-frames.Rmd
@@ -233,7 +233,7 @@ surveys[-c(7:34786),] #equivalent to head(surveys)
 ```
 
 As well as using numeric values to subset a `data.frame` (or `matrix`), columns
-can be called by name, using one the three following notations:
+can be called by name, using one of the three following notations:
 
 ```{r, eval = FALSE, purl=FALSE}
 surveys["species_id"]       # Result is a data.frame

--- a/04-dplyr.Rmd
+++ b/04-dplyr.Rmd
@@ -105,10 +105,10 @@ surveys %>%
 ```
 
 In the above we use the pipe to send the `surveys` data set first through
-`filter`, to keep rows where `weight` was less than 5, and then through `select` to
-keep the `species` and `sex` columns. When the data frame is being passed to the
-`filter()` and `select()` functions through a pipe, we don't need to include it
-as an argument to these functions anymore.
+`filter`, to keep rows where `weight` was less than 5, and then through `select`
+to keep the `species` and `sex` columns. When the data frame is being passed to
+the `filter()` and `select()` functions through a pipe, we don't need to include
+it as an argument to these functions anymore.
 
 If we wanted to create a new object with this smaller version of the data we
 could do so by assigning it a new name:

--- a/04-dplyr.Rmd
+++ b/04-dplyr.Rmd
@@ -32,7 +32,7 @@ Packages in R are basically sets of additional functions that let you do more
 stuff. The functions we've been using so far, like `str()` or `data.frame()`,
 come built into R; packages give you access to more of them. Before you use a
 package for the first time you need to install it on your machine, and then you
-should to import it in every subsequent R session when you'll need it.
+should import it in every subsequent R session when you need it.
 
 ```{r, eval = FALSE, purl = FALSE}
 install.packages("dplyr")

--- a/04-dplyr.Rmd
+++ b/04-dplyr.Rmd
@@ -243,9 +243,9 @@ screen anymore. That's because `dplyr` has changed our `data.frame` to a
 `tbl_df`. This is a data structure that's very similar to a data frame; for our
 purposes the only difference is that it won't automatically show tons of data
 going off the screen, while displaying the data type for each column under its
-name. If you want to display more data on the screen, you can add the `print()
-function at the end of the with the argument `n` specifying the number of rows
-to display:
+name. If you want to display more data on the screen, you can add the `print()`
+function at the end with the argument `n` specifying the number of rows to
+display:
 
 
 ```{r, purl = FALSE}

--- a/04-dplyr.Rmd
+++ b/04-dplyr.Rmd
@@ -283,7 +283,7 @@ surveys %>%
   tally()
 ```
 
-Here, `tally()` is the action applied to the groups created to `group_by()` and
+Here, `tally()` is the action applied to the groups created by `group_by()` and
 counts the total number of records for each category.
 
 > ### Challenge {.challenge}

--- a/04-dplyr.Rmd
+++ b/04-dplyr.Rmd
@@ -105,7 +105,7 @@ surveys %>%
 ```
 
 In the above we use the pipe to send the `surveys` data set first through
-`filter`, to keep rows where `wgt` was less than 5, and then through `select` to
+`filter`, to keep rows where `weight` was less than 5, and then through `select` to
 keep the `species` and `sex` columns. When the data frame is being passed to the
 `filter()` and `select()` functions through a pipe, we don't need to include it
 as an argument to these functions anymore.

--- a/04-dplyr.Rmd
+++ b/04-dplyr.Rmd
@@ -52,8 +52,8 @@ The package `dplyr` provides easy tools for the most common data manipulation
 tasks. It is built to work directly with data frames. The thinking behind it was
 largely inspired by the package `plyr` which has been in use for some time but
 suffered from being slow in some cases.` dplyr` addresses this by porting much
-of the computation to C++. An additional feature is the ability to work with
-data stored directly in an external database. The benefits of doing this are
+of the computation to C++. An additional feature is the ability to work directly
+with data stored in an external database. The benefits of doing this are
 that the data can be managed natively in a relational database, queries can be
 conducted on that database, and only the results of the query returned.
 

--- a/04-dplyr.Rmd
+++ b/04-dplyr.Rmd
@@ -94,7 +94,7 @@ objects. You can also nest functions (i.e. one function inside of another).
 This is handy, but can be difficult to read if too many functions are nested as
 the process from inside out. The last option, pipes, are a fairly recent
 addition to R. Pipes let you take the output of one function and send it
-directly to the next, which is useful when you need to many things to the same
+directly to the next, which is useful when you need to do many things to the same
 data set.  Pipes in R look like `%>%` and are made available via the `magrittr`
 package installed as part of `dplyr`.
 

--- a/06-r-and-sql.Rmd
+++ b/06-r-and-sql.Rmd
@@ -34,7 +34,7 @@ others.
 
 # Connecting R to sqlite databases
 
-R can connect to databases through a number of packages.  In our case we we will
+R can connect to databases through a number of packages.  In our case we will
 use [RSQLite](http://cran.r-project.org/web/packages/RSQLite/index.html) to
 connect to existing SQLite3 databases.  However you should be able to connect on
 almost any database in R via

--- a/06-r-and-sql.Rmd
+++ b/06-r-and-sql.Rmd
@@ -36,7 +36,7 @@ others.
 
 R can connect to databases through a number of packages.  In our case we will
 use [RSQLite](http://cran.r-project.org/web/packages/RSQLite/index.html) to
-connect to existing SQLite3 databases.  However you should be able to connect on
+connect to existing SQLite3 databases.  However you should be able to connect to
 almost any database in R via
 [JDBC](http://cran.r-project.org/web/packages/RJDBC/index.html)
 or [ODBC](http://cran.r-project.org/web/packages/RODBC/index.html), or specific


### PR DESCRIPTION
Fixed a couple of typos. The `wgt` to `weight` change is important.
As is the addition of the missing backtick which broke styling.
I kept each fix in a single commit so you can cherry pick but I can also stash them if desired.