### PR TITLE
Capitalisation of RStudio and Rstudio

### DIFF
--- a/00-before-we-start.Rmd
+++ b/00-before-we-start.Rmd
@@ -103,11 +103,12 @@ The RStudio IDE open source product is free under the [Affero General Public Lic
 We will use RStudio IDE to write code, navigate the files found on our computer, inspect the variables we are going to create, and visualize the plots we will generate. RStudio can also be used for other things (e.g., version control, developing packages, writting Shiny apps) that we will not cover during the workshop.
 
 RStudio is divided into 4 "Panes": the editor for your scripts and documents
-(top-left), the R console (bottom-left), your environment/history (top-right),
-and your files/plots/packages/help/viewer (bottom-right). The placement of these
-panes and their content can be customized. One of the advantages of using
-RStudio is that all the information you need to write code is available in a
-single window. Additionally, with many shortcuts, autocompletion, and
+(top-left, in the default layout), the R console (bottom-left), your
+environment/history (top-right), and your files/plots/packages/help/viewer
+(bottom-right). The placement of these panes and their content can be customized
+(see menu, RStudio -> Preferences -> Pane Layout). One of the advantages of
+using RStudio is that all the information you need to write code is available in
+a single window. Additionally, with many shortcuts, autocompletion, and
 highlighting for the major file types you use while developing in R, RStudio
 will make typing easier and less error-prone.
 

--- a/00-before-we-start.Rmd
+++ b/00-before-we-start.Rmd
@@ -98,9 +98,9 @@ workshop, you only need a `data/` folder.
 
 Let's start by learning about [RStudio](https://www.rstudio.com/), the Integrated Development Environment (IDE).
 
-The RStudio IDE open source product is free under the [Affero General Public License (AGPL) v3](https://www.gnu.org/licenses/agpl-3.0.en.html). Rstudio IDE is also available with a commercial license and priority email support from Rstudio, Inc.
+The RStudio IDE open source product is free under the [Affero General Public License (AGPL) v3](https://www.gnu.org/licenses/agpl-3.0.en.html). RStudio IDE is also available with a commercial license and priority email support from RStudio, Inc.
 
-We will use Rstudio IDE to write code, navigate the files found on our computer, inspect the variables we are going to create, and visualize the plots we will generate. RStudio can also be used for other things (e.g., version control, developing packages, writting Shiny apps) that we will not cover during the workshop.
+We will use RStudio IDE to write code, navigate the files found on our computer, inspect the variables we are going to create, and visualize the plots we will generate. RStudio can also be used for other things (e.g., version control, developing packages, writting Shiny apps) that we will not cover during the workshop.
 
 RStudio is divided into 4 "Panes": the editor for your scripts and documents
 (top-left), the R console (bottom-left), your environment/history (top-right),


### PR DESCRIPTION
When reading the section in the first lesson ["Before we start"](https://github.com/lmsimp/R-ecology-lesson/blob/help-info/00-before-we-start.Rmd) I have found inconsistent use of the capitalisation of RStudio. I have fixed this in this PR. 

I have also added how to customise the pane layout of RStudio. I found that some attendees don't always have the default setup and knowing how to change this to match the instructors setup (if they so wish) is useful. As this is only adding a few words after the first mention of customisation of the panes, I included it in this branch as it is part of the same section as the typos I found. Hopefully this is clear in the two commits in this branch of this PR.

This is also to fulfil part I of the checkout procedure for the DC instructors training (attended Cambridge 19/20th September).
