### PR TITLE
I'm seeing `date` rather than `POSIXct`

### DIFF
--- a/02-starting-with-data.Rmd
+++ b/02-starting-with-data.Rmd
@@ -551,5 +551,5 @@ The resulting POSIXct vector can be added to `surveys` as a new column called `d
 ```{r, eval=FALSE, purl=FALSE}
 surveys$date<-ymd(paste(surveys$year, surveys$month, surveys$day, sep="-"))
 
-str(surveys) # notice the new column, with POSIXct as the class
+str(surveys) # notice the new column, with 'Date' as the class
 ```


### PR DESCRIPTION
I'm seeing `date` rather than `POSIXct`, using lubridate_1.6.0

```
library(lubridate)
surveys$date <- ymd(paste(surveys$year, 
                          surveys$month, 
                          surveys$day, 
                          sep = "-"))
str(surveys)

'data.frame':	34786 obs. of  14 variables:
 $ record_id      : int  1 72 224 266 349 363 435 506 588 661 ...
 $ month          : int  7 8 9 10 11 11 12 1 2 3 ...
 $ day            : int  16 19 13 16 12 12 10 8 18 11 ...
 $ year           : int  1977 1977 1977 1977 1977 1977 1977 1978 1978 1978 ...
 $ plot_id        : int  2 2 2 2 2 2 2 2 2 2 ...
 $ species_id     : Factor w/ 48 levels "AB","AH","AS",..: 16 16 16 16 16 16 16 16 16 16 ...
 $ sex            : Factor w/ 3 levels "","F","M": 3 3 1 1 1 1 1 1 3 1 ...
 $ hindfoot_length: int  32 31 NA NA NA NA NA NA NA NA ...
 $ weight         : int  NA NA NA NA NA NA NA NA 218 NA ...
 $ genus          : Factor w/ 26 levels "Ammodramus","Ammospermophilus",..: 13 13 13 13 13 13 13 13 13 13 ...
 $ species        : Factor w/ 40 levels "albigula","audubonii",..: 1 1 1 1 1 1 1 1 1 1 ...
 $ taxa           : Factor w/ 4 levels "Bird","Rabbit",..: 4 4 4 4 4 4 4 4 4 4 ...
 $ plot_type      : Factor w/ 5 levels "Control","Long-term Krat Exclosure",..: 1 1 1 1 1 1 1 1 1 1 ...
 $ date           : Date, format: "1977-07-16" "1977-08-19" "1977-09-13" ...
```

```
> sessionInfo()
R version 3.4.0 Patched (2017-05-10 r72670)
Platform: x86_64-w64-mingw32/x64 (64-bit)
Running under: Windows 7 x64 (build 7601) Service Pack 1

Matrix products: default

locale:
[1] LC_COLLATE=English_Australia.1252                           
[2] LC_CTYPE=Chinese (Simplified)_People's Republic of China.936
[3] LC_MONETARY=English_Australia.1252                          
[4] LC_NUMERIC=C                                                
[5] LC_TIME=English_Australia.1252                              

attached base packages:
[1] stats     graphics  grDevices utils     datasets  methods   base     

other attached packages:
[1] lubridate_1.6.0  forcats_0.2.0    bindrcpp_0.1     dplyr_0.7.0.9000 skimr_1.0       

loaded via a namespace (and not attached):
 [1] Rcpp_0.12.11          tidyr_0.6.3           crayon_1.3.2.9000     assertthat_0.2.0     
 [5] R6_2.2.1              magrittr_1.5          stringi_1.1.5         rlang_0.1.1          
 [9] rstudioapi_0.6.0.9000 fortunes_1.5-4        tools_3.4.0           stringr_1.2.0        
[13] glue_1.0.0            purrr_0.2.2.2         yaml_2.1.14           compiler_3.4.0       
[17] colformat_0.0.0.9000  bindr_0.1             tibble_1.3.3         

```

Please delete the text below before submitting your contribution. 

---

Thanks for contributing! If this contribution is for instructor training, please send an email to checkout@carpentries.org with a link to this contribution so we can record your progress. You’ve completed your contribution step for instructor checkout just by submitting this contribution.  

Please keep in mind that lesson maintainers are volunteers and it may be some time before they can respond to your contribution. Although not all contributions can be incorporated into the lesson materials, we appreciate your time and effort to improve the curriculum.  If you have any questions about the lesson maintenance process or would like to volunteer your time as a contribution reviewer, please contact Kate Hertweck (k8hertweck@gmail.com).  

---
