### PR TITLE
Added note on how to install missing package

### DIFF
--- a/02-starting-with-data.Rmd
+++ b/02-starting-with-data.Rmd
@@ -1,6 +1,6 @@
 ---
-title: Starting with data
-author: Data Carpentry contributors
+title: "Starting with data"
+author: "Data Carpentry contributors"
 minutes: 20
 ---
 
@@ -532,6 +532,18 @@ Start by loading the required package:
 ```{r load-package, message=FALSE, purl=FALSE}
 library(lubridate)
 ```
+
+> If you get an error message
+>
+> ```
+> Error in library(lubridate) : there is no package called 'lubridate'
+> ```
+>
+> then you will need to install the package before loading it.
+>
+> ```{r, eval=FALSE, purl=FALSE}
+> install.packages("lubridate")
+> ```
 
 Create a character vector from the `year`, `month`, and `day` columns of `surveys` using `paste()`:
 

--- a/CONTRIBUTING.Rmd
+++ b/CONTRIBUTING.Rmd
@@ -40,7 +40,7 @@ our
     or `add-tutorial-on-visualization`. *At your terminal:*
 
 	```bash
-	git checkout -b fix-typos-dplyr-lesson`
+	git checkout -b fix-typos-dplyr-lesson
 	```
 
 4.  Make your changes to the Rmd file. If you'd like to check the rendered


### PR DESCRIPTION
Suggested edit (as part of the instructor training checkout): I've added a blurb on how to install the `lubridate` package, if one gets an error prompt that it is missing.