### PR TITLE
Clarify head() and as.numeric()

### DIFF
--- a/02-starting-with-data.Rmd
+++ b/02-starting-with-data.Rmd
@@ -193,7 +193,7 @@ surveys[, 1]    # first column in the data frame (as a vector)
 surveys[1]      # first column in the data frame (as a data.frame)
 surveys[1:3, 7] # first three elements in the 7th column (as a vector)
 surveys[3, ]    # the 3rd element for all columns (as a data.frame)
-head_surveys <- surveys[1:6, ] # equivalent to head(surveys)
+head_surveys <- surveys[1:6, ] # equivalent to head_surveys <- head(surveys)
 ```
 
 `:` is a special function that creates numeric vectors of integers in increasing
@@ -343,14 +343,16 @@ as.character(sex)
 ```
 
 Converting factors where the levels appear as numbers (such as concentration
-levels, or years) to a numeric vector is a little trickier.  One method is to
-convert factors to characters and then numbers.  Another method is to use the
-`levels()` function. Compare:
+levels, or years) to a numeric vector is a little trickier. The `as.numeric()` 
+function returns the index values of the factor, not its levels, so it will 
+result in an entirely new (and unwanted in this case) set of numbers. 
+One method to avoid this is to convert factors to characters and then numbers.  
+Another method is to use the `levels()` function. Compare:
 
 ```{r, purl=TRUE}
 f <- factor(c(1990, 1983, 1977, 1998, 1990))
-as.numeric(f)               # wrong! and there is no warning...
-as.numeric(as.character(f)) # works...
+as.numeric(f)               # Wrong! And there is no warning...
+as.numeric(as.character(f)) # Works...
 as.numeric(levels(f))[f]    # The recommended way.
 ```
 


### PR DESCRIPTION
Clarified that `head_surveys <- surveys[1:6, ]` is equivalent to `to head_surveys <- head(surveys)`.

Added a brief explanation about why `as.numeric(f)` is wrong

Capitalised the start of two comments for consistency since the others start with capital letters

Please delete the text below before submitting your contribution. 

---

Thanks for contributing! If this contribution is for instructor training, please send an email to checkout@carpentries.org with a link to this contribution so we can record your progress. You’ve completed your contribution step for instructor checkout just by submitting this contribution.  

Please keep in mind that lesson maintainers are volunteers and it may be some time before they can respond to your contribution. Although not all contributions can be incorporated into the lesson materials, we appreciate your time and effort to improve the curriculum.  If you have any questions about the lesson maintenance process or would like to volunteer your time as a contribution reviewer, please contact Kate Hertweck (k8hertweck@gmail.com).  

---
