### PR TITLE
update call to "mammals" in sqlite to list tables

### DIFF
--- a/05-r-and-databases.Rmd
+++ b/05-r-and-databases.Rmd
@@ -93,7 +93,7 @@ Using a similar approach, you could connect to many other database management sy
 Let's take a closer look at the `mammals` database we just connected to:
 
 ```{r tables, results="markup"}
-mammals
+src_dbi(mammals)
 ```
 
 Just like a spreadsheet with multiple worksheets, a SQLite database can contain


### PR DESCRIPTION
To list the tables and get an output that reflects the text in lesson, use `src_dbi()`

The current code just calls mammals which results in a different output, and because sentences following the code state "Just like a spreadsheet with multiple worksheets, a SQLite databse can contain multiple tables. In this case three of them are listed in the tbls row in the output above (then lists plots, species, and surveys)" we should change.

With recent updates to `dplyr/dbplyr`, it looks like this is no longer the case when you simply call the db connection. To list the tables and get an output that reflects the text here, use `src_dbi`.