### PR TITLE
To avoid printing the column classes on screen when reading the file at the start of the section 

### DIFF
--- a/04-visualization-ggplot2.Rmd
+++ b/04-visualization-ggplot2.Rmd
@@ -7,7 +7,7 @@ minutes: 60
 
 ```{r setup, echo=FALSE, purl=FALSE}
 source("setup.R")
-surveys_complete <- read_csv(file = "data_output/surveys_complete.csv")
+surveys_complete <- read_csv(file = "data_output/surveys_complete.csv",col_types = cols())
 ```
 
 ```{r, echo=FALSE, purl=TRUE}


### PR DESCRIPTION
As this first step in this section, the earlier version of the command rendered  the column classes right at the start of the section. For illustration purposes, this was a bit misleading as there were no command shown on the screen before the column classes output, thus added a command to suppress printing column classes at the start of the section.

Please delete the text below before submitting your contribution. 

---

Thanks for contributing! If this contribution is for instructor training, please send an email to checkout@carpentries.org with a link to this contribution so we can record your progress. You’ve completed your contribution step for instructor checkout just by submitting this contribution.  

Please keep in mind that lesson maintainers are volunteers and it may be some time before they can respond to your contribution. Although not all contributions can be incorporated into the lesson materials, we appreciate your time and effort to improve the curriculum.  If you have any questions about the lesson maintenance process or would like to volunteer your time as a contribution reviewer, please contact Kate Hertweck (k8hertweck@gmail.com).  

---
