### PR TITLE
Consistent styling

### DIFF
--- a/01-intro-to-r.Rmd
+++ b/01-intro-to-r.Rmd
@@ -56,8 +56,8 @@ for assignments, but not in every context. Because of the
 in syntax, it is good practice to always use `<-` for assignments.
 
 In RStudio, typing <kbd>Alt</kbd> + <kbd>-</kbd> (push <kbd>Alt</kbd> at the
-same time as the <kbd>-</kbd> key) will write ` <- ` in a single keystroke.
-
+same time as the <kbd>-</kbd> key) will write ` <- ` in a single keystroke in a PC, while typing <kbd>Option</kbd> + <kbd>-</kbd> (push <kbd>Option</kbd> at the
+same time as the <kbd>-</kbd> key) does the same in a Mac.
 
 Objects can be given any name such as `x`, `current_temperature`, or
 `subject_id`. You want your object names to be explicit and not too long. They

--- a/03-dplyr.Rmd
+++ b/03-dplyr.Rmd
@@ -101,7 +101,7 @@ This is referred to as a "tibble"
 Tibbles are data frames, but they tweak some of the old behaviors of data frames. The data structure is very similar to a data frame. For our purposes the only differences are that:
 1. In addition to displaying the data type of each column under its name, it only prints the first few rows of data and only as many columns as fit
 on one screen.
-2. Columns of class `character` are never converted into factors automatically while loading the dataset.
+2. Columns of class `character` are never implicitly converted into factors.
 
 ## Selecting columns and filtering rows
 

--- a/03-dplyr.Rmd
+++ b/03-dplyr.Rmd
@@ -101,7 +101,7 @@ This is referred to as a "tibble"
 Tibbles are data frames, but they tweak some of the old behaviors of data frames. The data structure is very similar to a data frame. For our purposes the only differences are that:
 1. In addition to displaying the data type of each column under its name, it only prints the first few rows of data and only as many columns as fit
 on one screen.
-2. Columns of class `character` are never converted into factors.
+2. Columns of class `character` are never converted into factors automatically while loading the dataset.
 
 ## Selecting columns and filtering rows
 

--- a/04-visualization-ggplot2.Rmd
+++ b/04-visualization-ggplot2.Rmd
@@ -7,7 +7,7 @@ minutes: 60
 
 ```{r setup, echo=FALSE, purl=FALSE}
 source("setup.R")
-surveys_complete <- read_csv(file = "data_output/surveys_complete.csv")
+surveys_complete <- read_csv(file = "data_output/surveys_complete.csv",col_types = cols())
 ```
 
 ```{r, echo=FALSE, purl=TRUE}

--- a/04-visualization-ggplot2.Rmd
+++ b/04-visualization-ggplot2.Rmd
@@ -7,7 +7,7 @@ minutes: 60
 
 ```{r setup, echo=FALSE, purl=FALSE}
 source("setup.R")
-surveys_complete <- read_csv(file = "data_output/surveys_complete.csv",col_types = cols())
+surveys_complete <- read_csv(file = "data_output/surveys_complete.csv", col_types = cols())
 ```
 
 ```{r, echo=FALSE, purl=TRUE}


### PR DESCRIPTION
To be consistent with other chapters in the lesson where shortcuts are mentioned for both Windows and Mac OS, added a shortcut for mac for the <- operator for mac in 01-intro-to-r lesson.

A more pedantic issue, specifically mentioned that: "Columns of class character are never converted into factors automatically while loading the dataset."