### PR TITLE
Link DOIs to preferred resolver

### DIFF
--- a/CITATION.Rmd
+++ b/CITATION.Rmd
@@ -62,7 +62,7 @@ Chihuahuan Desert ecosystem near Portal, Arizona, USA. Ecology 90:1708.
 http://esapubs.org/archive/ecol/E090/118/
 
 A simplified version of this data, suitable for teaching is available on
-[figshare](https://dx.doi.org/10.6084/m9.figshare.1314459.v5).
+[figshare](https://doi.org/10.6084/m9.figshare.1314459.v5).
 
 
 ## Lessons

--- a/CONTRIBUTING.Rmd
+++ b/CONTRIBUTING.Rmd
@@ -120,7 +120,7 @@ data may be provided in any way that is convenient including
 posting to a website, on [figshare](http://figshare.com/), a public
 Dropbox link, a [GitHub gist](https://gist.github.com), or even
 included in the pull request (PR). Once the PR is ready to merge the data should
-be placed in the [official data repository](https://dx.doi.org/10.6084/m9.figshare.1314459.v5)
+be placed in the [official data repository](https://doi.org/10.6084/m9.figshare.1314459.v5)
 and all links to the data updated.
 
 ## Formatting of the material

--- a/index.Rmd
+++ b/index.Rmd
@@ -48,7 +48,7 @@ the data and install everything *before* working through this lesson.
 
 ### Data
 
-Data files for the lesson are available and can be downloaded manually here: <http://dx.doi.org/10.6084/m9.figshare.1314459>
+Data files for the lesson are available and can be downloaded manually here: <https://doi.org/10.6084/m9.figshare.1314459>
 
 However, we will download them directly from R during the lessons when we need
 them.


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new, secure resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). Accordingly, this PR updates some static DOI links.

Cheers!