### PR TITLE
Import data from Import Dataset > From Text (readr) ...

### DIFF
--- a/02-starting-with-data.Rmd
+++ b/02-starting-with-data.Rmd
@@ -58,10 +58,19 @@ download.file("https://ndownloader.figshare.com/files/2292169",
               "data/portal_data_joined.csv")
 ```
 
-You are now ready to load the data:
+You are now ready to load the data. Importing a dataset into R can be challenging. It often results in silent issues that cause severe errors later in your data analysis. Getting this right is important, and also it is simple if you use RStudio and the __readr__ package.
+
+A simple way to import this dataset is from the Environment tab of RStudio, using the option Import Dataset > From Text (readr) ... 
+
+![](https://i.imgur.com/e9gG380.png)
+
+The panel that pops-up will help you to find the file you want to import, and show you useful previews of the data (central panel) and code (bottom left) that the selected options generate.
+
+![](https://i.imgur.com/2aBq0Ei.png)
 
 ```{r, eval=TRUE,  purl=FALSE}
-surveys <- read.csv("data/portal_data_joined.csv")
+library(readr)
+surveys <- read_csv("data/portal_data_joined.csv")
 ```
 
 This statement doesn't produce any output because, as you might recall,


### PR DESCRIPTION
RStudio provides a GUI interface to import datasets. This, combined with the __readr__ package solves a number of common and important problems. 

* Reduces frustration because most students are familiar with GUI and not with typing paths.
* Avoids converting strings to factors -- a topic that is too early to address. `readr::read_csv()` defaults to `stringsAsFactors = TRUE`.
* Introduces students to `readr::read_csv()` ASAP. Some cool features the students may want to know about include:
    * it lets user specify what to interpret as `NA`, 
    * it lets user specify column types. 

I show an example [here](https://fgeo.netlify.com/2018/03/13/2018-03-13-import-dataset/).
