### PR TITLE
Count for combination of factor in the dplyr lesson

### DIFF
--- a/03-dplyr.Rmd
+++ b/03-dplyr.Rmd
@@ -409,6 +409,23 @@ surveys %>%
     count(sex, sort = TRUE) 
 ```
 
+Previous example shows the use of `count()` to count the number of rows/observations for *one* factor (i.e., `sex`). If we wanted to count *combination of factors*, such as `sex` and `species`, we would specify the first and the second factor as the arguments of `count()`:
+
+```{r purl = FALSE}
+surveys %>%
+  count(sex, species) 
+```
+
+With the above code, we can proceed with `arrange()` to sort the table according to a number of criteria so that we have a better comparison. For instance, we might want to arrange the table above in (i) an alphabetical order of the levels of the species and (ii) in descending order of the count:
+
+```{r purl = FALSE}
+surveys %>%
+  count(sex, species) %>%
+  arrange(species, desc(n))
+```
+
+From the table above, we may learn that, for instance, there are 75 observations of the *albigula* species that are not specified for its sex (i.e. `NA`).
+
 > ### Challenge {.challenge}
 >
 > 1. How many individuals were caught in each `plot_type` surveyed?

--- a/03-dplyr.Rmd
+++ b/03-dplyr.Rmd
@@ -409,14 +409,20 @@ surveys %>%
     count(sex, sort = TRUE) 
 ```
 
-Previous example shows the use of `count()` to count the number of rows/observations for *one* factor (i.e., `sex`). If we wanted to count *combination of factors*, such as `sex` and `species`, we would specify the first and the second factor as the arguments of `count()`:
+Previous example shows the use of `count()` to count the number of rows/observations 
+for *one* factor (i.e., `sex`). 
+If we wanted to count *combination of factors*, such as `sex` and `species`, 
+we would specify the first and the second factor as the arguments of `count()`:
 
 ```{r purl = FALSE}
 surveys %>%
   count(sex, species) 
 ```
 
-With the above code, we can proceed with `arrange()` to sort the table according to a number of criteria so that we have a better comparison. For instance, we might want to arrange the table above in (i) an alphabetical order of the levels of the species and (ii) in descending order of the count:
+With the above code, we can proceed with `arrange()` to sort the table 
+according to a number of criteria so that we have a better comparison. 
+For instance, we might want to arrange the table above in (i) an alphabetical order of 
+the levels of the species and (ii) in descending order of the count:
 
 ```{r purl = FALSE}
 surveys %>%
@@ -424,7 +430,8 @@ surveys %>%
   arrange(species, desc(n))
 ```
 
-From the table above, we may learn that, for instance, there are 75 observations of the *albigula* species that are not specified for its sex (i.e. `NA`).
+From the table above, we may learn that, for instance, there are 75 observations of 
+the *albigula* species that are not specified for its sex (i.e. `NA`).
 
 > ### Challenge {.challenge}
 >


### PR DESCRIPTION
I add two code-chunks in the "03-dplyr.Rmd" lesson in the **counting** section.
The first chunk shows how to generate **co-occurrence** count between _a set of factors_ (i.e. `sex` and `species`) using `dplyr::count()`, complementing the example of `dplyr::count()` for a single factor (i.e. `sex`). 
The second chunk shows the use of `dplyr::arrange()` to sort the co-occurrence count given _a set of criteria_, complementing the previous example for `dplyr::arrange()` before the **counting** section.