### PR TITLE
added chunk to section on `counting`

### DIFF
--- a/03-dplyr.Rmd
+++ b/03-dplyr.Rmd
@@ -402,8 +402,15 @@ surveys %>%
     count(sex) 
 ```
 
-For convenience, `count()` provides the `sort` argument:
+The `count()` function is shorthand for something we've already seen: grouping by a variable, and summarizing it by counting the number of observations in that group. In other words, `surveys %>% count()` is equivalent to:  
 
+```{r, purl = FALSE}
+surveys %>%
+    group_by(sex) %>%
+    summarise(count = n())
+```
+
+For convenience, `count()` provides the `sort` argument:  
 
 ```{r, purl = FALSE}
 surveys %>%


### PR DESCRIPTION
Explained that `count()` is shorthand for `group_by() %>% summarise(count = n())`, and why it is useful.

Please delete the text below before submitting your contribution. 
