### PR TITLE
fix typo in joins image

### DIFF
--- a/img/joins.svg
+++ b/img/joins.svg
@@ -6,6 +6,8 @@
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    style="fill-rule:evenodd;stroke-width:28.22200012;stroke-linejoin:round"
    id="svg944"
    xml:space="preserve"
@@ -13,10 +15,31 @@
    viewBox="0 0 15321.111 12759.111"
    height="127.59111mm"
    width="153.21111mm"
-   version="1.2"><metadata
+   version="1.2"
+   inkscape:version="0.48.4 r9939"
+   sodipodi:docname="joins.svg"><sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1871"
+     inkscape:window-height="1056"
+     id="namedview490"
+     showgrid="false"
+     inkscape:zoom="1.9351251"
+     inkscape:cx="271.43701"
+     inkscape:cy="230.08416"
+     inkscape:window-x="49"
+     inkscape:window-y="24"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg944" /><metadata
      id="metadata948"><rdf:RDF><cc:Work
          rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" /><dc:title></dc:title></cc:Work></rdf:RDF></metadata><defs
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" /><dc:title /></cc:Work></rdf:RDF></metadata><defs
      id="defs8"
      class="ClipPathGroup"><clipPath
        clipPathUnits="userSpaceOnUse"
@@ -461,7 +484,7 @@
                    d="m 8083,13256 h 2293 v 970 H 8083 Z" /><text
                    id="text238"
                    class="TextShape"><tspan
-                     style="font-weight:400;font-size:423px;font-family:Calibri, sans-serif"
+                     style="font-size:423px;font-weight:400;font-family:'Calibri, sans-serif'"
                      id="tspan236"
                      font-weight="400"
                      font-size="423px"
@@ -471,7 +494,7 @@
                        x="9589"
                        class="TextPosition"><tspan
                          style="fill:#000000;stroke:none"
-                         id="tspan232">1.2</tspan></tspan></tspan></text>
+                         id="tspan232">2.9</tspan></tspan></tspan></text>
 <path
                    style="fill:#e6e6ff;stroke:none"
                    id="path240"
@@ -512,7 +535,7 @@
                    d="m 8083,14226 h 2293 v 970 H 8083 Z" /><text
                    id="text268"
                    class="TextShape"><tspan
-                     style="font-weight:400;font-size:423px;font-family:Calibri, sans-serif"
+                     style="font-size:423px;font-weight:400;font-family:'Calibri, sans-serif'"
                      id="tspan266"
                      font-weight="400"
                      font-size="423px"
@@ -522,7 +545,7 @@
                        x="9589"
                        class="TextPosition"><tspan
                          style="fill:#000000;stroke:none"
-                         id="tspan262">3.3</tspan></tspan></tspan></text>
+                         id="tspan262">1.2</tspan></tspan></tspan></text>
 <path
                    style="fill:none;stroke:#ffffff"
                    id="path270"


### PR DESCRIPTION
This fixes a typo in the schematic representation of `inner_join()` of the `dbplyr` lesson. 

This is mentioned in #454, so should fix that part of the issue.