### PR TITLE
Specifying_argument_name_with_download.file

### DIFF
--- a/02-starting-with-data.Rmd
+++ b/02-starting-with-data.Rmd
@@ -60,8 +60,8 @@ you'll download the file. So this command downloads a file from figshare, names 
 "portal_data_joined.csv," and adds it to a preexisting folder named "data."
 
 ```{r, eval=FALSE, purl=TRUE}
-download.file("https://ndownloader.figshare.com/files/2292169",
-              "data/portal_data_joined.csv")
+download.file(url="https://ndownloader.figshare.com/files/2292169",
+              destfile = "data/portal_data_joined.csv")
 ```
 
 You are now ready to load the data:


### PR DESCRIPTION
This contribution relates to the “starting with Data” section of the Data Analysis and Visualization in R for Ecologists lesion. In this section, trainees are shown how to use the download.file() function to download a dataset for the lesion as below:
`download.file("https://ndownloader.figshare.com/files/2292169", “data/portal_data_joined.csv”).`
As this is the first time trainees will be using this function to download data from the web, I think it should be clarified that this function takes in two arguments; the first argument being the url and the second argument being the destination file. The way the arguments are currently written ("https://ndownloader.figshare.com/files/2292169", “data/portal_data_joined.csv”) it might all be mistaken for one url or two url links separated by a comma and not the url and destination file. So I have introduced argument names (url and destfile) in Ln63-64 to make it clearer. as below.
`download.file("https://ndownloader.figshare.com/files/2292169",` “data/portal_data_joined.csv”)`