### PR TITLE
Clarify logic examples

### DIFF
--- a/01-intro-to-r.Rmd
+++ b/01-intro-to-r.Rmd
@@ -467,6 +467,7 @@ You can combine multiple tests using `&` (both conditions are true, AND) or `|`
 ```{r, results = 'show', purl = FALSE}
 weight_g[weight_g > 30 & weight_g < 50]
 weight_g[weight_g <= 30 | weight_g == 55]
+weight_g[weight_g >= 30 & weight_g == 21]
 ```
 
 Here, `>` for "greater than", `<` stands for "less than", `<=` for "less than

--- a/01-intro-to-r.Rmd
+++ b/01-intro-to-r.Rmd
@@ -465,11 +465,11 @@ You can combine multiple tests using `&` (both conditions are true, AND) or `|`
 (at least one of the conditions is true, OR):
 
 ```{r, results = 'show', purl = FALSE}
-weight_g[weight_g < 30 | weight_g > 50]
-weight_g[weight_g >= 30 & weight_g == 21]
+weight_g[weight_g > 30 & weight_g < 50]
+weight_g[weight_g <= 30 | weight_g == 55]
 ```
 
-Here, `<` stands for "less than", `>` for "greater than", `>=` for "greater than
+Here, `>` for "greater than", `<` stands for "less than", `<=` for "less than
 or equal to", and `==` for "equal to". The double equal sign `==` is a test for
 numerical equality between the left and right hand sides, and should not be
 confused with the single `=` sign, which performs variable assignment (similar

--- a/02-starting-with-data.Rmd
+++ b/02-starting-with-data.Rmd
@@ -564,7 +564,7 @@ integer values.
 ```{r, eval=FALSE, purl=FALSE}
 str(surveys)
 ```
-We are going to use the `ymd()` function from the package **`lubridate`** (which belongs to the **`tidyverse`**; learn more [here](https://www.tidyverse.org/)). . **`lubridate`** gets installed as part as the **`tidyverse`** installation. When you load  the **`tidyverse`** (`library(tidyverse)`), the core packages (the packages used in most data analyses) get loaded. **`lubridate`** however does not belong to the core tidyverse, so you have to load it explicitly with `library(lubridate)`
+We are going to use the `ymd()` function from the package **`lubridate`** (which belongs to the **`tidyverse`**; learn more [here](https://www.tidyverse.org/)). **`lubridate`** gets installed as part as the **`tidyverse`** installation. When you load  the **`tidyverse`** (`library(tidyverse)`), the core packages (the packages used in most data analyses) get loaded. **`lubridate`** however does not belong to the core tidyverse, so you have to load it explicitly with `library(lubridate)`
 
 Start by loading the required package:
 


### PR DESCRIPTION
This edit is in response to confusion by learners at a workshop I co-instructed last week. In the previous version, the second example of combining boolean operators:
```
weight_g[weight_g >= 30 & weight_g == 21]
```
returned `#> numeric(0)` because a value cannot be >= 30 AND == 21. Because this is the first exposure to conditionals for most learners, an affirmative example, that doesn't return a NULL value, would be better. I've changed both examples so that all the same boolean operators (`>`, `<`, `<=`, `==`) are still used, and both examples return valid vectors.
