### PR TITLE
replace species_id with genus in ggsave code

### DIFF
--- a/04-visualization-ggplot2.Rmd
+++ b/04-visualization-ggplot2.Rmd
@@ -630,7 +630,7 @@ Make sure you have the `fig/` folder in your working directory.
 my_plot <- ggplot(data = yearly_sex_counts, 
                   mapping = aes(x = year, y = n, color = sex)) +
     geom_line() +
-    facet_wrap(vars(species_id)) +
+    facet_wrap(vars(genus)) +
     labs(title = "Observed genera through time",
         x = "Year of observation",
         y = "Number of individuals") +


### PR DESCRIPTION
Addresses issue with use of `species_id` instead of `genus` in the `ggsave` example at the end of the lesson. Specifically replaces
`facet_wrap(vars(species_id))` with `facet_wrap(vars(genus))`

Fixes Issue 602:  https://github.com/datacarpentry/R-ecology-lesson/issues/602
