### PR TITLE
include script file saving

### DIFF
--- a/01-intro-to-r.Rmd
+++ b/01-intro-to-r.Rmd
@@ -16,7 +16,8 @@ source("setup.R")
 > * Define the following terms as they relate to R: object, assign, call,
 >   function, arguments, options.
 > * Create objects and assign values to them  in R.
-> * Learn how to _name_ objects
+> * Learn how to _name_ objects.
+> * Save a script file for later use.
 > * Use comments to inform script.
 > * Solve simple arithmetic operations in R.
 > * Call functions and use arguments to change their default options.
@@ -129,6 +130,21 @@ weight_kg <- 100
 ```
 
 What do you think is the current content of the object `weight_lb`? 126.5 or 220?
+
+### Saving your code
+
+Up to now, your code has been in the console. This is useful for quick queries
+but not so helpful if you want to revist your work for any reason.
+A script can be opened by pressing the <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + 
+<kbd>N</kbd>. 
+It it wise to save your script file immediately. To do this press <kbd>Shift</kbd> + 
+<kbd>S</kbd>. This will open a dialogue box where you can decide where to save 
+your script file, and what to name it. The .R file extension is added automatically
+and ensures your file will open with R Studio.
+
+Don't forget to save your work periodically by pressing <kbd>Shift</kbd> + 
+<kbd>S</kbd>.
+
 
 ### Comments
 


### PR DESCRIPTION
Introduce saving scripts.

Guidance didn't include explicit instructions to save scripts. 
Included basic step by step instructions before main lesson to save a script and continue saving.