### PR TITLE
remove quotation marks in `library()` calls

### DIFF
--- a/02-starting-with-data.Rmd
+++ b/02-starting-with-data.Rmd
@@ -564,12 +564,12 @@ integer values.
 ```{r, eval=FALSE, purl=FALSE}
 str(surveys)
 ```
-We are going to use the `ymd()` function from the package **`lubridate`** (which belongs to the **`tidyverse`**; learn more [here](https://www.tidyverse.org/)). **`lubridate`** gets installed as part as the **`tidyverse`** installation. When you load  the **`tidyverse`** (`library("tidyverse")`), the core packages (the packages used in most data analyses) get loaded. **`lubridate`** however does not belong to the core tidyverse, so you have to load it explicitly with `library(lubridate)`
+We are going to use the `ymd()` function from the package **`lubridate`** (which belongs to the **`tidyverse`**; learn more [here](https://www.tidyverse.org/)). **`lubridate`** gets installed as part as the **`tidyverse`** installation. When you load  the **`tidyverse`** (`library(tidyverse)`), the core packages (the packages used in most data analyses) get loaded. **`lubridate`** however does not belong to the core tidyverse, so you have to load it explicitly with `library(lubridate)`
 
 Start by loading the required package:
 
 ```{r load-package, message=FALSE, purl=FALSE}
-library("lubridate")
+library(lubridate)
 ```
 
 `ymd()` takes a vector representing year, month, and day, and converts it to a

--- a/03-dplyr.Rmd
+++ b/03-dplyr.Rmd
@@ -68,7 +68,7 @@ Then, to load the package type:
 
 ```{r, message = FALSE, purl = FALSE}
 ## load the tidyverse packages, incl. dplyr
-library("tidyverse")
+library(tidyverse)
 ```
 
 ## What are **`dplyr`** and **`tidyr`**?

--- a/04-visualization-ggplot2.Rmd
+++ b/04-visualization-ggplot2.Rmd
@@ -36,7 +36,7 @@ surveys_complete <- read_csv(file = "data_raw/portal_data_joined.csv", col_types
 We start by loading the required packages. **`ggplot2`** is included in the **`tidyverse`** package.
 
 ```{r load-package, message=FALSE, purl=FALSE}
-library("tidyverse")
+library(tidyverse)
 ```
 
 If not still in the workspace, load the data we saved in the previous lesson.
@@ -160,7 +160,7 @@ surveys_plot
 >
 > ```{r, eval = FALSE}
 > install.packages("hexbin")
-> library("hexbin")
+> library(hexbin)
 > ```
 >
 > Then use the `geom_hex()` function:
@@ -181,7 +181,7 @@ surveys_plot
 ## package from CRAN:
 
 install.packages("hexbin")
-library("hexbin")
+library(hexbin)
 
 ## Then use the `geom_hex()` function:
 

--- a/05-r-and-databases.Rmd
+++ b/05-r-and-databases.Rmd
@@ -87,8 +87,8 @@ download.file(url = "https://ndownloader.figshare.com/files/2292171",
 We can point R to this database using:
 
 ```{r connect, purl=TRUE}
-library("dplyr")
-library("dbplyr")
+library(dplyr)
+library(dbplyr)
 mammals <- DBI::dbConnect(RSQLite::SQLite(), "data_raw/portal_mammals.sqlite")
 ```
 
@@ -502,7 +502,7 @@ download.file("https://ndownloader.figshare.com/files/10717177",
               "data_raw/surveys.csv")
 download.file("https://ndownloader.figshare.com/files/3299474",
               "data_raw/plots.csv")
-library("tidyverse")
+library(tidyverse)
 species <- read_csv("data_raw/species.csv")
 surveys <- read_csv("data_raw/surveys.csv")
 plots <- read_csv("data_raw/plots.csv")


### PR DESCRIPTION
Quoting package names in `library()` is not necessary and disables auto-completion of package names in RStudio. 
