### PR TITLE
closes #586 confusing example

### DIFF
--- a/02-starting-with-data.Rmd
+++ b/02-starting-with-data.Rmd
@@ -223,8 +223,8 @@ surveys[1, 6]
 surveys[, 1]    
 # first column of the data frame (as a data.frame)
 surveys[1]      
-# first three elements in the 7th column (as a vector)
-surveys[1:3, 7] 
+# first three rows of the 6th column (as a vector)
+surveys[1:3, 6] 
 # the 3rd row of the data frame (as a data.frame)
 surveys[3, ]    
 # equivalent to head_surveys <- head(surveys)


### PR DESCRIPTION
when the 7th column is a factor vector, the result has two elements, although 3 were requested, because one element is blank. With the 6th column this is not the case.
Also changed "elements" to "rows" for consistency.

closes #586