### PR TITLE
closes #471 unclear question "How many species...?"

### DIFF
--- a/02-starting-with-data.Rmd
+++ b/02-starting-with-data.Rmd
@@ -174,7 +174,7 @@ objects besides `data.frame`.
 >
 > * What is the class of the object `surveys`?
 > * How many rows and how many columns are in this object?
-> * How many species have been recorded during these surveys?
+> * How many genera have been recorded during these surveys? (Hint: genera is the plural of genus).
 >
 > ```{r, answer=TRUE, results="markup", purl=FALSE}
 >
@@ -182,7 +182,7 @@ objects besides `data.frame`.
 >
 > ## * class: data frame
 > ## * how many rows: 34786,  how many columns: 13
-> ## * how many species: 48
+> ## * how many genera: There are 26 unique genera in the `genus` column."
 >
 > ```
 

--- a/02-starting-with-data.Rmd
+++ b/02-starting-with-data.Rmd
@@ -182,7 +182,7 @@ objects besides `data.frame`.
 >
 > ## * class: data frame
 > ## * how many rows: 34786,  how many columns: 13
-> ## * how many genera: There are 26 unique genera in the `genus` column."
+> ## * how many genera: There are 26 unique genera in the `genus` column.
 >
 > ```
 


### PR DESCRIPTION
The species column has fewer unique entries than species_id. The relation between genera and species can be unclear to learners without biology background. Asking about genera fulfills the same learning objective but is less ambiguous.