### PR TITLE
closes #627, add missing font workaround for ggplot to instructor notes

### DIFF
--- a/instructor-notes.md
+++ b/instructor-notes.md
@@ -68,6 +68,11 @@ On older versions of MacOS, it may happen that axis labels do not show up when c
 Arial being deactivated, so that R cannot find it. To resolve this issue, go to Finder, 
 Search for Font Book and open it. Look for the Arial font and, if it is greyed out, turn it on. 
 
+If the problem occurs with `ggplot2` plots, an alternative workaround is to change the default 
+theme for the R session, so that ggplot uses a _serif_ font. Since Arial is a _sans-serif_ 
+font, R will try to load a different font. This can be done with 
+`theme_update(text = element_text(family = "serif"))`. 
+
 ## Narrative
 
 ### Before we start


### PR DESCRIPTION
@rachellombardi reported a workaround for missing Arial font in ggplots on older Macs. I've added (slightly modified) instructions to the instructor notes.