### PR TITLE
add Extras tab for code handout and instructor notes to navbar

### DIFF
--- a/_navbar.html
+++ b/_navbar.html
@@ -31,8 +31,14 @@
         <li>
           <a href="05-r-and-databases.html">R and SQL</a>
         </li>
-        <li>
-          <a href="code-handout.R">Code Handout</a>
+        <li class="dropdown">
+          <a class="dropdown-toggle" data-toggle="dropdown" href="#">
+            Extras<span class="caret"></span>
+          </a>
+          <ul class="dropdown-menu">
+            <li><a href="code-handout.R">Download Code Handout</a></li>
+            <li><a href="instructor-notes.html">Instructor Notes</a></li>
+          </ul>
         </li>
       </ul>
 


### PR DESCRIPTION
- Instructor notes cannot be accessed from the course website, only via the [Data Carpentry site](https://datacarpentry.org/lessons/#ecology-workshop). 
- The code handout should not be a top level menu item
- Other carpentry courses have an "Extras" menu item for things like this

This commit addresses these issues by adding an "Extras" dropdown menu item to the navbar, with an entry for the code handout and the instructor notes.