### PR TITLE
Update subsetting for tibbles (#680)

### DIFF
--- a/02-starting-with-data.Rmd
+++ b/02-starting-with-data.Rmd
@@ -254,22 +254,47 @@ want from it. Row numbers come first, followed by column numbers. However, note
 that different ways of specifying these coordinates lead to results with
 different classes.
 
-
 ```{r, purl=FALSE}
-# first element in the first column of the data frame (as a vector)
-surveys[1, 1]   
-# first element in the 6th column (as a vector)
+# We can extract specific values by specifying row and column indices
+# in the format: 
+# data_frame[row_index, column_index]
+# For instance, to extract the first row and column from surveys:
+surveys[1, 1]
+
+# First row, sixth column:
 surveys[1, 6]   
-# first column of the data frame (as a vector)
-surveys[, 1]    
-# first column of the data frame (as a data.frame)
-surveys[1]      
-# first three rows of the 6th column (as a vector)
-surveys[1:3, 6] 
-# the 3rd row of the data frame (as a data.frame)
-surveys[3, ]    
-# equivalent to head_surveys <- head(surveys)
-head_surveys <- surveys[1:6, ] 
+
+# We can also use shortcuts to select a number of rows or columns at once
+# To select all columns, leave the column index blank
+# For instance, to select the all columns for the first row:
+surveys[1, ]
+
+# The same shortcut works for rows --
+# To select the first column across all rows:
+surveys[, 1]
+
+# An even shorter way to select first column across all rows:
+surveys[1] # No comma! 
+
+# To select multiple rows or columns, use vectors!
+# To select the first three rows of the 5th and 6th column
+surveys[c(1, 2, 3), c(5, 6)] 
+
+# We can use the : operator to create those vectors for us:
+surveys[1:3, 5:6] 
+
+# This is equivalent to head_surveys <- head(surveys)
+head_surveys <- surveys[1:6, ]
+
+# As we've seen, when working with tibbles 
+# subsetting with single square brackets ("[]") always returns a data frame.
+# If you want a vector, use double square brackets ("[[]]")
+
+# For instance, to get the first column as a vector:
+surveys[[1]]
+
+# To get the first value in our data frame:
+surveys[[1, 1]]
 ```
 
 `:` is a special function that creates numeric vectors of integers in increasing
@@ -278,17 +303,23 @@ or decreasing order, test `1:10` and `10:1` for instance.
 You can also exclude certain indices of a data frame using the "`-`" sign:
 
 ```{r, purl=FALSE}
-surveys[, -1]          # The whole data frame, except the first column
+surveys[, -1]         # The whole data frame, except the first column
 surveys[-(7:34786), ] # Equivalent to head(surveys)
 ```
 
 Data frames can be subset by calling indices (as shown previously), but also by calling their column names directly:
 
 ```{r, eval = FALSE, purl=FALSE}
-surveys["species_id"]       # Result is a data.frame
-surveys[, "species_id"]     # Result is a vector
-surveys[["species_id"]]     # Result is a vector
-surveys$species_id          # Result is a vector
+# As before, using single brackets returns a data frame:
+surveys["species_id"]
+surveys[, "species_id"]
+
+# Double brackets returns a vector:
+surveys[["species_id"]]
+
+# We can also use the $ operator with names in the place of double brackets
+# This returns a vector:
+surveys$species_id
 ```
 
 In RStudio, you can use the autocompletion feature to get the full and correct names of the columns.

--- a/02-starting-with-data.Rmd
+++ b/02-starting-with-data.Rmd
@@ -304,7 +304,7 @@ You can also exclude certain indices of a data frame using the "`-`" sign:
 
 ```{r, purl=FALSE}
 surveys[, -1]         # The whole data frame, except the first column
-surveys[-(7:34786), ] # Equivalent to head(surveys)
+surveys[-(7:nrow(surveys)), ] # Equivalent to head(surveys)
 ```
 
 Data frames can be subset by calling indices (as shown previously), but also by calling their column names directly:

--- a/02-starting-with-data.Rmd
+++ b/02-starting-with-data.Rmd
@@ -266,7 +266,7 @@ surveys[1, 6]
 
 # We can also use shortcuts to select a number of rows or columns at once
 # To select all columns, leave the column index blank
-# For instance, to select the all columns for the first row:
+# For instance, to select all columns for the first row:
 surveys[1, ]
 
 # The same shortcut works for rows --
@@ -303,7 +303,7 @@ or decreasing order, test `1:10` and `10:1` for instance.
 You can also exclude certain indices of a data frame using the "`-`" sign:
 
 ```{r, purl=FALSE}
-surveys[, -1]         # The whole data frame, except the first column
+surveys[, -1]                 # The whole data frame, except the first column
 surveys[-(7:nrow(surveys)), ] # Equivalent to head(surveys)
 ```
 
@@ -317,7 +317,7 @@ surveys[, "species_id"]
 # Double brackets returns a vector:
 surveys[["species_id"]]
 
-# We can also use the $ operator with names in the place of double brackets
+# We can also use the $ operator with column names instead of double brackets
 # This returns a vector:
 surveys$species_id
 ```


### PR DESCRIPTION
This is my attempt at rewriting the section around subsetting to consider the more consistent behavior of tibbles, which is what our novices will be principally using. 

There is a call-out that this behavior should only be expected when working with tibbles on line 289. I agree that it's not worth diving into the differences between base data frames and tibbles at this level, but I do want to at least flag "this is not universally true." If this feels likely to confuse, though, happy to remove it.