### PR TITLE
clarified effect of using incorrect import function in instructor notes

### DIFF
--- a/instructor-notes.md
+++ b/instructor-notes.md
@@ -161,7 +161,7 @@ The two main goals for this lessons are:
   command to select the columns "weight_kg" and "weight_lb" makes it easier
   to view how the "weight" columns are changed.
 * Clarify the differences between the functions read_csv() (used in this lesson) and read.csv() (used in the previous lesson).
-* Note: If students import the data and get 30521 rows instead of the expected 30463 rows, then they have likely used `read.csv()` and not `read_csv()` to import the data
+* Note: If students end up with 30521 rows for `surveys_complete` instead of the expected 30463 rows at the end of the chapter, then they have likely used `read.csv()` and not `read_csv()` to import the data
 
 ### Visualizing data
 


### PR DESCRIPTION
Clarified in [instructor notes](https://github.com/datacarpentry/R-ecology-lesson/blob/main/instructor-notes.md) that if final result of `surveys_complete` has incorrect number of rows, then students likely used `read.csv()` instead of `read_csv()` as noted in issue #682 