### PR TITLE
fix broken link in instructor notes

### DIFF
--- a/instructor-notes.md
+++ b/instructor-notes.md
@@ -213,7 +213,7 @@ service the computer have things set up, it may be very difficult to impossible
 to make R work without their help. 
 
 If learners are having issues with one package, they may have issues with 
-another. Its often easier to [make sure they have all the necessary packages installed](#required-packages) 
+another. It iss often easier to [make sure they have all the necessary packages installed](#required-packages) 
 at one time, rather then deal with these issues over and over.
 
 

--- a/instructor-notes.md
+++ b/instructor-notes.md
@@ -213,9 +213,9 @@ service the computer have things set up, it may be very difficult to impossible
 to make R work without their help. 
 
 If learners are having issues with one package, they may have issues with 
-another. Its often easier to make sure they have all the needed packages 
-installed at one time, rather then deal with these issues over and over.
-[Here is a list of all necessary packages for these lessons.](https://github.com/datacarpentry/R-ecology-lesson/blob/main/needed_packages.R)
+another. Its often easier to [make sure they have all the necessary packages installed](#required-packages) 
+at one time, rather then deal with these issues over and over.
+
 
 ## Other Resources
 

--- a/instructor-notes.md
+++ b/instructor-notes.md
@@ -213,7 +213,7 @@ service the computer have things set up, it may be very difficult to impossible
 to make R work without their help. 
 
 If learners are having issues with one package, they may have issues with 
-another. It iss often easier to [make sure they have all the necessary packages installed](#required-packages) 
+another. It is often easier to [make sure they have all the necessary packages installed](#required-packages) 
 at one time, rather then deal with these issues over and over.
 
 


### PR DESCRIPTION
There used to be a separate R script with all the required packages that is now part of the instructor notes.  This PR removes a dead link to that script from the instructor notes and adds an internal link to a list of these packages in the same document.

closes #713