### PR TITLE
add challenge about boxplot outlier plotting

### DIFF
--- a/04-visualization-ggplot2.Rmd
+++ b/04-visualization-ggplot2.Rmd
@@ -294,6 +294,10 @@ hidden?
 > - Create boxplot for `hindfoot_length`.  Overlay the boxplot layer on a jitter
 >   layer to show actual measurements.
 >
+> - What effect does the `alpha` parameter in the boxplot layer have on the outlier
+>   points? Can you achieve the same visualisation without changing the transparency?
+>   Hint: Check the `geom_boxplot` parameters starting with `outlier...`.
+>
 > - Add color to the data points on your boxplot according to the plot from which
 >   the sample was taken (`plot_id`).
 


### PR DESCRIPTION
I added a question to the challenges after the boxplot section that asks learners to reflect on the alpha parameter and its effects. It doesn't get clarified elsewhere that setting alpha to zero for the boxplot layer leads to the removal of the outlier points.
When we taught the material, we noticed that the parameter often got removed during the exercises, which leads to double-plotting of the outliers, once in the boxplot and once in the jitter layer.
I thought it could be helpful to make it part of the challenge to understand this behaviour and find a way of combining a jitter and a boxplot layer without duplicated outliers and without changing the transparency.