### PR TITLE
Match challenge answer to prompt & style fix

### DIFF
--- a/05-r-and-databases.Rmd
+++ b/05-r-and-databases.Rmd
@@ -395,8 +395,8 @@ retrieved.
 > 
 > left_join(surveys, species) %>%
 >   filter(taxa == "Rodent") %>%
->   group_by(taxa, year) %>%
->   tally %>%
+>   group_by(taxa, year, plot_id) %>%
+>   tally() %>%
 >   collect()
 > 
 > ## with SQL syntax
@@ -450,7 +450,7 @@ retrieved.
 >   left_join(species) %>%
 >   filter(taxa == "Rodent") %>%
 >   group_by(plot_type, genus) %>%
->   tally %>%
+>   tally() %>%
 >   collect()
 > ```
 


### PR DESCRIPTION
The challenge starting in line 374 requests the number of rodents observed in each plot, in each year. However, the dplyr syntax answer only groups by taxa and year. I have added 'plot_id' to line 398, so that the output matches the prompt. 

In addition, the code chunks starting in line 396 and 449 use 'tally', which I replaced with 'tally()' to match the tidyverse style guide.
