### PR TITLE
Issue 759 avoid easy

### DIFF
--- a/00-before-we-start.Rmd
+++ b/00-before-we-start.Rmd
@@ -46,8 +46,8 @@ results of your analysis do not rely on remembering a succession of pointing and
 clicking, but instead on a series of written commands, and that's a good thing!
 So, if you want to redo your analysis because you collected more data, you don't
 have to remember which button you clicked in which order to obtain your results.
-You run repeat running your series of commands (your script) and R will process
-the new dataset exactly the same way. 
+With a stored series of commands (this is your script), you can repeat running them and
+R will process the new dataset exactly the same way as before.
 
 Working with scripts makes the steps you used in your analysis clear, and the
 code you write can be inspected by someone else who can give you feedback and

--- a/00-before-we-start.Rmd
+++ b/00-before-we-start.Rmd
@@ -232,7 +232,7 @@ your project, it should refer to files in relation to the root of your working
 directory and only need files within this structure.
 
 RStudio assists you in this regard and sets the working directory automatically
-to the directory placed your project in.
+to the directory where you have placed your project in.
 If you need to check it, you can use `getwd()`. If for some
 reason your working directory is not what it should be, you can change it in the
 RStudio interface by navigating in the file browser where your working directory

--- a/00-before-we-start.Rmd
+++ b/00-before-we-start.Rmd
@@ -2,8 +2,8 @@
 title: "Before we start"
 author: "Data Carpentry contributors"
 minutes: 15
-editor_options: 
-  markdown: 
+editor_options:
+  markdown:
     wrap: 80
 ---
 
@@ -45,8 +45,9 @@ The learning curve might be steeper than with other software, but with R, the
 results of your analysis do not rely on remembering a succession of pointing and
 clicking, but instead on a series of written commands, and that's a good thing!
 So, if you want to redo your analysis because you collected more data, you don't
-have to remember which button you clicked in which order to obtain your results;
-you just have to run your script again.
+have to remember which button you clicked in which order to obtain your results.
+You run repeat running your series of commands (your script) and R will process
+the new dataset exactly the same way. 
 
 Working with scripts makes the steps you used in your analysis clear, and the
 code you write can be inspected by someone else who can give you feedback and
@@ -142,14 +143,14 @@ It is good practice to keep a set of related data, analyses, and text
 self-contained in a single folder, called the **working directory**. All of the
 scripts within this folder can then use *relative paths* to files that indicate
 where inside the project a file is located (as opposed to absolute paths, which
-point to where a file is on a specific computer). Working this way makes it a
-lot easier to move your project around on your computer and share it with others
+point to where a file is on a specific computer). Working this way allows you to
+move your project around on your computer and share it with others
 without worrying about whether or not the underlying scripts will still work.
 
 RStudio provides a helpful set of tools to do this through its "Projects"
 interface, which not only creates a working directory for you, but also
 remembers its location (allowing you to quickly navigate to it) and optionally
-preserves custom settings and open files to make it easier to resume work after
+preserves custom settings and (re-)open files to assist resume work after
 a break. Go through the steps for creating an "R Project" for this tutorial
 below.
 
@@ -171,7 +172,7 @@ user-defined object. By default, all of these objects will be saved, and
 automatically loaded, when you reopen your project. Saving a workspace to
 `.RData` can be cumbersome, especially if you are working with larger datasets,
 and it can lead to hard to debug errors by having objects in memory you forgot
-you had. Therefore, it is often a good idea to turn this off. To do so, go to 
+you had. Therefore, it is often a good idea to turn this off. To do so, go to
 Tools --\> 'Global Options' and select the 'Never' option for
 'Save workspace to .RData' on exit.'
 
@@ -181,7 +182,7 @@ Tools --\> 'Global Options' and select the 'Never' option for
 ### Organizing your working directory
 
 Using a consistent folder structure across your projects will help keep things
-organized, and will also make it easy to find/file things in the future. This
+organized, and will help you to find/file things in the future. This
 can be especially helpful when you have multiple projects. In general, you may
 create directories (folders) for **scripts**, **data**, and **documents**.
 
@@ -214,7 +215,8 @@ we will use `data/` for when we learn how to export data as CSV files, and a
     folder.
 
 We are going to keep the script in the root of our working directory because we
-are only going to use one file and it will make things easier.
+are only going to use one file. Later, when you start create more
+complex projects, it might make sense to organize scripts in sub-directories.
 
 Your working directory should now look like this:
 
@@ -229,8 +231,9 @@ from where R will be looking for and saving the files. When you write code for
 your project, it should refer to files in relation to the root of your working
 directory and only need files within this structure.
 
-Using RStudio projects makes this easy and ensures that your working directory
-is set properly. If you need to check it, you can use `getwd()`. If for some
+RStudio assists you in this regard and sets the working directory automatically
+to the directory placed your project in.
+If you need to check it, you can use `getwd()`. If for some
 reason your working directory is not what it should be, you can change it in the
 RStudio interface by navigating in the file browser where your working directory
 should be, and clicking on the blue gear icon "More", and select "Set As Working
@@ -387,7 +390,7 @@ Besides that, there are a few places on the internet that provide help:
 
 The key to receiving help from someone is for them to rapidly grasp your
 problem. Thus, you should be as precise as possible when describing your problem
-and make it easy to pinpoint where the issue might be. Try to...
+and help others to pinpoint where the issue might be. Try to...
 
 -   Use the correct words to describe your problem. Otherwise you might get an
     answer pointing to the misuse of your words rather than answering your
@@ -433,7 +436,8 @@ The best way to become proficient and efficient at R, as with any other tool, is
 to use it to address your actual research questions. As a beginner, it can feel
 daunting to have to write a script from scratch, and given that many people make
 their code available online, modifying existing code to suit your purpose might
-make it easier for you to get started.
+get first hands-on experience using R for your own work and help you become
+comfortable eventually creating your own scripts.
 
 ```{r kitten-img, results='markup', echo=FALSE, purl=FALSE, out.width='400px', fig.align='center'}
 knitr::include_graphics("img/kitten-try-things.jpg")

--- a/01-intro-to-r.Rmd
+++ b/01-intro-to-r.Rmd
@@ -49,7 +49,7 @@ weight_kg <- 55
 ```
 
 `<-` is the assignment operator. It assigns values on the right to objects on
-the left. So, after executing `x <- 3`, the value of `x` is `3`. The arrow also looks like a mouth (with tongue), which makes it easy to pronounce as `x` **eats** 3.  For historical reasons, you can also use `=`
+the left. So, after executing `x <- 3`, the value of `x` is `3`.   For historical reasons, you can also use `=`
 for assignments, but not in every context. Because of the
 [slight](https://blog.revolutionanalytics.com/2008/12/use-equals-or-arrow-for-assignment.html)
 [differences](https://r.789695.n4.nabble.com/Is-there-any-difference-between-and-tp878594p878598.html)
@@ -68,7 +68,7 @@ Objects can be given almost any name such as `x`, `current_temperature`, or `sub
 [here](https://stat.ethz.ch/R-manual/R-devel/library/base/html/Reserved.html)
 for a complete list). In general, even if it's allowed, it's best to not use
 other function names (e.g., `c`, `T`, `mean`, `data`, `df`, `weights`). If in
-doubt, check the help to see if the name is already in use. 
+doubt, check the help to see if the name is already in use.
 * It's best to avoid dots (`.`) within names. Many function names in R itself have them and dots also have a special meaning (methods) in R and other programming languages. To avoid confusion, don't include dots in names.
 * It is recommended to use nouns for object names and verbs for function names.
 * Be consistent in the styling of your code, such as where you put spaces, how you name objects, etc. Styles can include "lower_snake", "UPPER_SNAKE", "lowerCamelCase", "UpperCamelCase", etc. Using a consistent coding style makes your code clearer to read for your future self and your collaborators. In R, three popular style guides come from [Google](https://google.github.io/styleguide/Rguide.xml), [Jean
@@ -126,15 +126,15 @@ What do you think is the current content of the object `weight_lb`? 126.5 or 220
 
 Up to now, your code has been in the console. This is useful for quick queries
 but not so helpful if you want to revisit your work for any reason.
-A script can be opened by pressing <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + 
-<kbd>N</kbd>. 
-It is wise to save your script file immediately. To do this press 
-<kbd>Ctrl</kbd> + <kbd>S</kbd>. This will open a dialogue box where you 
+A script can be opened by pressing <kbd>Ctrl</kbd> + <kbd>Shift</kbd> +
+<kbd>N</kbd>.
+It is wise to save your script file immediately. To do this press
+<kbd>Ctrl</kbd> + <kbd>S</kbd>. This will open a dialogue box where you
 can decide where to save your script file, and what to name it.
 The `.R` file extension is added automatically and ensures your file
 will open with RStudio.
 
-Don't forget to save your work periodically by pressing <kbd>Ctrl</kbd> + 
+Don't forget to save your work periodically by pressing <kbd>Ctrl</kbd> +
 <kbd>S</kbd>.
 
 
@@ -146,8 +146,8 @@ scripts.
 RStudio makes it easy to comment or uncomment a paragraph: after selecting the
 lines you  want to comment, press at the same time on your keyboard
 <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>C</kbd>. If you only want to comment
-out one line, you can put the cursor at any location of that line (i.e. no need 
-to select the whole line), then press <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + 
+out one line, you can put the cursor at any location of that line (i.e. no need
+to select the whole line), then press <kbd>Ctrl</kbd> + <kbd>Shift</kbd> +
 <kbd>C</kbd>.
 
 > ### Challenge
@@ -215,7 +215,7 @@ round(3.14159)
 Here, we've called `round()` with just one argument, `3.14159`, and it has
 returned the value `3`.  That's because the default is to round to the nearest
 whole number. If we want more digits we can see how to do that by getting
-information about the `round` function.  We can use `args(round)` to find what 
+information about the `round` function.  We can use `args(round)` to find what
 arguments it takes, or look at the
 help for this function using `?round`.
 
@@ -323,7 +323,7 @@ We can do this over and over again to grow a vector, or assemble a dataset.
 As we program, this may be useful to add results that we are collecting or
 calculating.
 
-An **atomic vector** is the simplest R **data type** and is a linear vector of a single type. Above, we saw 
+An **atomic vector** is the simplest R **data type** and is a linear vector of a single type. Above, we saw
 2 of the 6 main **atomic vector** types  that R
 uses: `"character"` and `"numeric"` (or `"double"`). These are the basic building blocks that
 all R objects are built from. The other 4 **atomic vector** types are:
@@ -347,7 +347,7 @@ factors (`factor`) and arrays (`array`).
 > * We’ve seen that atomic vectors can be of type character,
 >   numeric (or double), integer, and logical. But what happens if we try to mix these types in
 >   a single vector?
-> 
+>
 > ```{text_answer, echo=FALSE, purl=FALSE}
 > R implicitly converts them to all be the same type
 > ```
@@ -495,13 +495,13 @@ a search vector are found:
 animals <- c("mouse", "rat", "dog", "cat", "cat")
 
 # return both rat and cat
-animals[animals == "cat" | animals == "rat"] 
+animals[animals == "cat" | animals == "rat"]
 
 # return a logical vector that is TRUE for the elements within animals
 # that are found in the character vector and FALSE for those that are not
 animals %in% c("rat", "cat", "dog", "duck", "goat", "bird", "fish")
 
-# use the logical vector created by %in% to return elements from animals 
+# use the logical vector created by %in% to return elements from animals
 # that are found in the character vector
 animals[animals %in% c("rat", "cat", "dog", "duck", "goat", "bird", "fish")]
 ```
@@ -509,9 +509,9 @@ animals[animals %in% c("rat", "cat", "dog", "duck", "goat", "bird", "fish")]
 > ### Challenge (optional){.challenge}
 >
 > * Can you figure out why `"four" > "five"` returns `TRUE`?
-> 
+>
 > ```{text_answer, echo=FALSE, purl=FALSE}
-> When using ">" or "<" on strings, R compares their alphabetical order. 
+> When using ">" or "<" on strings, R compares their alphabetical order.
 > Here "four" comes after "five", and therefore is "greater than" it.
 > ```
 
@@ -551,11 +551,11 @@ examples.
 ## Extract those elements which are not missing values.
 heights[!is.na(heights)]
 
-## Returns the object with incomplete cases removed. 
+## Returns the object with incomplete cases removed.
 #The returned object is an atomic vector of type `"numeric"` (or #`"double"`).
 na.omit(heights)
 
-## Extract those elements which are complete cases. 
+## Extract those elements which are complete cases.
 #The returned object is an atomic vector of type `"numeric"` (or #`"double"`).
 heights[complete.cases(heights)]
 ```
@@ -574,9 +574,9 @@ Recall that you can use the `typeof()` function to find the type of your atomic 
 >
 > ```{r, answer=TRUE}
 > heights <- c(63, 69, 60, 65, NA, 68, 61, 70, 61, 59, 64, 69, 63, 63, NA, 72, 65, 64, 70, 63, 65)
-> 
+>
 > # 1.
-> heights_no_na <- heights[!is.na(heights)] 
+> heights_no_na <- heights[!is.na(heights)]
 > # or
 > heights_no_na <- na.omit(heights)
 > # or

--- a/01-intro-to-r.Rmd
+++ b/01-intro-to-r.Rmd
@@ -143,7 +143,7 @@ Don't forget to save your work periodically by pressing <kbd>Ctrl</kbd> +
 The comment character in R is `#`.  Anything to the right of a `#` in a script
 will be ignored by R. It is useful to leave notes and explanations in your
 scripts.
-RStudio makes it easy to comment or uncomment a paragraph: after selecting the
+For convenience, RStudio provides a keyboard shortcut to comment or uncomment a paragraph: after selecting the
 lines you  want to comment, press at the same time on your keyboard
 <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>C</kbd>. If you only want to comment
 out one line, you can put the cursor at any location of that line (i.e. no need
@@ -191,7 +191,7 @@ weight_kg <- sqrt(10)
 
 Here, the value of 10 is given to the `sqrt()` function, the `sqrt()` function
 calculates the square root, and returns the value which is then assigned to
-the object `weight_kg`. This function is very simple, because it takes just one argument.
+the object `weight_kg`. This function takes one argument, other functions might take several. 
 
 The return 'value' of a function need not be numerical (like that of `sqrt()`),
 and it also does not need to be a single item: it can be a set of things, or

--- a/03-dplyr.Rmd
+++ b/03-dplyr.Rmd
@@ -36,7 +36,7 @@ suppressWarnings(surveys$date <- lubridate::ymd(paste(surveys$year,
 
 Bracket subsetting is handy, but it can be cumbersome and difficult to read,
 especially for complicated operations. Enter **`dplyr`**. **`dplyr`** is a package for
-helping wit tabular data manipulation. It pairs nicely with **`tidyr`** which enables you to swiftly convert between different data formats for plotting and analysis.
+helping with tabular data manipulation. It pairs nicely with **`tidyr`** which enables you to swiftly convert between different data formats for plotting and analysis.
 
 The **`tidyverse`** package is an
 "umbrella-package" that installs **`tidyr`**, **`dplyr`**, and several other useful packages for data analysis, such as  **`ggplot2`**, **`tibble`**, etc.

--- a/03-dplyr.Rmd
+++ b/03-dplyr.Rmd
@@ -36,7 +36,7 @@ suppressWarnings(surveys$date <- lubridate::ymd(paste(surveys$year,
 
 Bracket subsetting is handy, but it can be cumbersome and difficult to read,
 especially for complicated operations. Enter **`dplyr`**. **`dplyr`** is a package for
-making tabular data manipulation easier. It pairs nicely with **`tidyr`** which enables you to swiftly convert between different data formats for plotting and analysis.
+helping wit tabular data manipulation. It pairs nicely with **`tidyr`** which enables you to swiftly convert between different data formats for plotting and analysis.
 
 The **`tidyverse`** package is an
 "umbrella-package" that installs **`tidyr`**, **`dplyr`**, and several other useful packages for data analysis, such as  **`ggplot2`**, **`tibble`**, etc.
@@ -610,9 +610,9 @@ and then gathering can be a useful way to balance out a dataset so every
 replicate has the same composition.
 
 We could also have used a specification for what columns to include. This can be
-useful if you have a large number of identifying columns, and it's easier to
+useful if you have a large number of identifying columns, and it's allows you to type less in order to
 specify what to gather than what to leave alone. And if the columns are directly
-adjacent, we don't even need to list them all out - just use the `:` operator!
+adjacent, we don't even need to list them all out - instead you can use the `:` operator!
 
 ```{r, purl=FALSE}
 surveys_spread %>%

--- a/03-dplyr.Rmd
+++ b/03-dplyr.Rmd
@@ -610,7 +610,7 @@ and then gathering can be a useful way to balance out a dataset so every
 replicate has the same composition.
 
 We could also have used a specification for what columns to include. This can be
-useful if you have a large number of identifying columns, and it's allows you to type less in order to
+useful if you have a large number of identifying columns, and it allows you to type less in order to
 specify what to gather than what to leave alone. And if the columns are directly
 adjacent, we don't even need to list them all out - instead you can use the `:` operator!
 

--- a/03-dplyr.Rmd
+++ b/03-dplyr.Rmd
@@ -50,12 +50,12 @@ doing data analysis in R:
 3. The existence of hidden arguments having default operations that new learners are not aware
    of.
 
-You should already have installed and loaded the **`tidyverse`** package. 
+You should already have installed and loaded the **`tidyverse`** package.
 If you haven't already done so, you can type `install.packages("tidyverse")` straight into the console. Then, type `library(tidyverse)` to load the package.
 
 ## What are **`dplyr`** and **`tidyr`**?
 
-The package **`dplyr`** provides easy tools for the most common data manipulation
+The package **`dplyr`** provides helper tools for the most common data manipulation
 tasks. It is built to work directly with data frames, with many common tasks
 optimized by being written in a compiled language (C++). An additional feature is the
 ability to work directly with data stored in an external database. The benefits of
@@ -81,7 +81,7 @@ To learn more about **`dplyr`** and **`tidyr`** after the workshop, you may want
 [handy data transformation with **`dplyr`** cheatsheet](https://github.com/rstudio/cheatsheets/raw/master/data-transformation.pdf)
 and this [one about **`tidyr`**](https://github.com/rstudio/cheatsheets/raw/master/data-import.pdf).
 
-As before, we'll read in our data using the `read_csv()` function from the 
+As before, we'll read in our data using the `read_csv()` function from the
 tidyverse package **`readr`**.
 
 
@@ -163,7 +163,7 @@ the output of one function and send it directly to the next, which is useful
 when you need to do many things to the same dataset.  Pipes in R look like
 `%>%` and are made available via the **`magrittr`** package, installed automatically
 with **`dplyr`**. If you use RStudio, you can type the pipe with <kbd>Ctrl</kbd>
-+ <kbd>Shift</kbd> + <kbd>M</kbd> if you have a PC or <kbd>Cmd</kbd> + 
++ <kbd>Shift</kbd> + <kbd>M</kbd> if you have a PC or <kbd>Cmd</kbd> +
 <kbd>Shift</kbd> + <kbd>M</kbd> if you have a Mac.
 
 ```{r, purl = FALSE}
@@ -203,8 +203,8 @@ Note that the final data frame is the leftmost part of this expression.
 >
 >  Using pipes, subset the `surveys` data to include animals collected before
 >  1995 and retain only the columns `year`, `sex`, and `weight`.
-> 
-> 
+>
+>
 > ```{r, answer=TRUE, eval=FALSE, purl=FALSE}
 > surveys %>%
 >     filter(year < 1995) %>%
@@ -271,7 +271,7 @@ symbol negates the result, so we're asking for every row where weight *is not* a
 >  than 3.
 >
 >  **Hint**: think about how the commands should be ordered to produce this data frame!
-> 
+>
 > ```{r, answer=TRUE, eval=FALSE, purl=FALSE}
 > surveys_hindfoot_cm <- surveys %>%
 >     filter(!is.na(hindfoot_length)) %>%
@@ -279,7 +279,7 @@ symbol negates the result, so we're asking for every row where weight *is not* a
 >     filter(hindfoot_cm < 3) %>%
 >     select(species_id, hindfoot_cm)
 > ```
- 
+
 
 ```{r, eval=FALSE, purl=TRUE, echo=FALSE}
 ## Mutate Challenge:
@@ -296,11 +296,11 @@ symbol negates the result, so we're asking for every row where weight *is not* a
 
 Many data analysis tasks can be approached using the *split-apply-combine*
 paradigm: split the data into groups, apply some analysis to each group, and
-then combine the results. **`dplyr`** makes this very easy through the use of the
-`group_by()` function.
+then combine the results. Key function of **`dplyr`** for this workflow are
+`group_by()` and `summarize()`.
 
 
-#### The `summarize()` function
+#### The `group_by()` and `summarize()` functions
 
 `group_by()` is often used together with `summarize()`, which collapses each
 group into a single-row summary of that group.  `group_by()` takes as arguments
@@ -321,18 +321,18 @@ You can also group by multiple columns:
 ```{r, purl = FALSE}
 surveys %>%
   group_by(sex, species_id) %>%
-  summarize(mean_weight = mean(weight, na.rm = TRUE)) %>% 
+  summarize(mean_weight = mean(weight, na.rm = TRUE)) %>%
   tail()
 ```
 
-Here, we used `tail()` to look at the last six rows of our summary. Before, we had 
-used `head()` to look at the first six rows. We can see that the `sex` column contains 
-`NA` values because some animals had escaped before their sex and body weights 
-could be determined. The resulting `mean_weight` column does not contain `NA` but 
-`NaN` (which refers to "Not a Number") because `mean()` was called on a vector of 
-`NA` values while at the same time setting `na.rm = TRUE`. To avoid this, we can 
-remove the missing values for weight before we attempt to calculate the summary 
-statistics on weight. Because the missing values are removed first, we can omit 
+Here, we used `tail()` to look at the last six rows of our summary. Before, we had
+used `head()` to look at the first six rows. We can see that the `sex` column contains
+`NA` values because some animals had escaped before their sex and body weights
+could be determined. The resulting `mean_weight` column does not contain `NA` but
+`NaN` (which refers to "Not a Number") because `mean()` was called on a vector of
+`NA` values while at the same time setting `na.rm = TRUE`. To avoid this, we can
+remove the missing values for weight before we attempt to calculate the summary
+statistics on weight. Because the missing values are removed first, we can omit
 `na.rm = TRUE` when computing the mean:
 
 ```{r, purl = FALSE}
@@ -400,7 +400,7 @@ each sex, we would do:
 
 ```{r, purl = FALSE}
 surveys %>%
-    count(sex) 
+    count(sex)
 ```
 
 The `count()` function is shorthand for something we've already seen: grouping by a variable, and summarizing it by counting the number of observations in that group. In other words, `surveys %>% count()` is equivalent to:  
@@ -415,22 +415,22 @@ For convenience, `count()` provides the `sort` argument:
 
 ```{r, purl = FALSE}
 surveys %>%
-    count(sex, sort = TRUE) 
+    count(sex, sort = TRUE)
 ```
 
-Previous example shows the use of `count()` to count the number of rows/observations 
-for *one* factor (i.e., `sex`). 
-If we wanted to count *combination of factors*, such as `sex` and `species`, 
+Previous example shows the use of `count()` to count the number of rows/observations
+for *one* factor (i.e., `sex`).
+If we wanted to count *combination of factors*, such as `sex` and `species`,
 we would specify the first and the second factor as the arguments of `count()`:
 
 ```{r purl = FALSE}
 surveys %>%
-  count(sex, species) 
+  count(sex, species)
 ```
 
-With the above code, we can proceed with `arrange()` to sort the table 
-according to a number of criteria so that we have a better comparison. 
-For instance, we might want to arrange the table above in (i) an alphabetical order of 
+With the above code, we can proceed with `arrange()` to sort the table
+according to a number of criteria so that we have a better comparison.
+For instance, we might want to arrange the table above in (i) an alphabetical order of
 the levels of the species and (ii) in descending order of the count:
 
 ```{r purl = FALSE}
@@ -439,7 +439,7 @@ surveys %>%
   arrange(species, desc(n))
 ```
 
-From the table above, we may learn that, for instance, there are 75 observations of 
+From the table above, we may learn that, for instance, there are 75 observations of
 the *albigula* species that are not specified for its sex (i.e. `NA`).
 
 > ### Challenge {.challenge}
@@ -448,7 +448,7 @@ the *albigula* species that are not specified for its sex (i.e. `NA`).
 >
 > ```{r, answer=TRUE, purl=FALSE}
 > surveys %>%
->     count(plot_type) 
+>     count(plot_type)
 > ```
 >
 > 2. Use `group_by()` and `summarize()` to find the mean, min, and max hindfoot
@@ -507,14 +507,14 @@ dataset:
 Here we examine the fourth rule: Each type of observational unit forms a table.
 
 In `surveys`, the rows of `surveys` contain the values of variables associated
-with each record (the unit), values such as the weight or sex of each animal 
-associated with each record. What if instead of comparing records, we 
+with each record (the unit), values such as the weight or sex of each animal
+associated with each record. What if instead of comparing records, we
 wanted to compare the different mean weight of each genus between plots? (Ignoring `plot_type` for simplicity).
 
 We'd need to create a new table where each row (the unit) is comprised of values of variables associated with each plot. In practical terms this means the values
 in `genus` would become the names of column variables and the cells would contain the values of the mean weight observed on each plot.
 
-Having created a new table, it is therefore straightforward to explore the 
+Having created a new table, it is therefore straightforward to explore the
 relationship between the weight of different genera within, and between, the
 plots. The key point here is that we are still following a tidy data structure,
 but we have **reshaped** the data according to the observations of interest:
@@ -530,16 +530,16 @@ and `gather()`.
 
 `spread()` takes three principal arguments:
 
-1. the data 
+1. the data
 2. the *key* column variable whose values will become new column names.  
 3. the *value* column variable whose values will fill the new column variables.
 
-Further arguments include `fill` which, if set, fills in missing values with 
+Further arguments include `fill` which, if set, fills in missing values with
 the value provided.
 
-Let's use `spread()` to transform surveys to find the mean weight of each 
+Let's use `spread()` to transform surveys to find the mean weight of each
 genus in each plot over the entire survey period. We use `filter()`,
-`group_by()` and `summarise()` to filter our observations and variables of 
+`group_by()` and `summarise()` to filter our observations and variables of
 interest, and create a new variable for the `mean_weight`.
 
 ```{r, purl=FALSE}
@@ -552,7 +552,7 @@ str(surveys_gw)
 ```
 
 This yields `surveys_gw` where the observations for each plot are spread across
-multiple rows, 196 observations of 3 variables. 
+multiple rows, 196 observations of 3 variables.
 Using `spread()` to key on `genus` with values from `mean_weight` this becomes
 24 observations of 11 variables, one row for each plot.
 
@@ -565,7 +565,7 @@ str(surveys_spread)
 
 ![](img/spread_data_R.png)
 
-We could now plot comparisons between the weight of genera (one is called a genus, multiple are called genera) in different plots, 
+We could now plot comparisons between the weight of genera (one is called a genus, multiple are called genera) in different plots,
 although we may wish to fill in the missing values first.
 
 ```{r, purl=FALSE}
@@ -577,7 +577,7 @@ surveys_gw %>%
 #### Gathering
 
 The opposing situation could occur if we had been provided with data in the
-form of `surveys_spread`, where the genus names are column names, but we 
+form of `surveys_spread`, where the genus names are column names, but we
 wish to treat them as values of a genus variable instead.
 
 In this situation we are gathering the column names and turning them into a
@@ -588,7 +588,7 @@ the other variable contains the values previously associated with the column nam
 
 1. the data
 2. the *key* column variable we wish to create from column names.
-3. the *values* column variable we wish to create and fill with values 
+3. the *values* column variable we wish to create and fill with values
 associated with the key.
 4. the names of the columns we use to fill the key variable (or to drop).
 
@@ -622,19 +622,19 @@ surveys_spread %>%
 
 > ### Challenge {.challenge}
 >
-> 1. Spread the `surveys` data frame with `year` as columns, `plot_id` 
+> 1. Spread the `surveys` data frame with `year` as columns, `plot_id`
 >   as rows, and the
 >   number of genera per plot as the values. You will need to summarize before
 >   reshaping, and use the function `n_distinct()` to get the number of unique
 >   genera within a particular chunk of data. It's a powerful function! See
 >   `?n_distinct` for more.
-> 
+>
 > ```{r, answer=TRUE, purl=FALSE}
 > surveys_spread_genera <- surveys %>%
 >   group_by(plot_id, year) %>%
 >   summarize(n_genera = n_distinct(genus)) %>%
 >   spread(year, n_genera)
-> 
+>
 > head(surveys_spread_genera)
 > ```
 >
@@ -726,7 +726,7 @@ observations for these more common species:
 ```{r, purl=FALSE}
 ## Extract the most common species_id
 species_counts <- surveys_complete %>%
-    count(species_id) %>% 
+    count(species_id) %>%
     filter(n >= 50)
 
 ## Only keep the most common species
@@ -747,7 +747,7 @@ surveys_complete <- surveys %>%
 ##  Now remove rare species in two steps. First, make a list of species which
 ##  appear at least 50 times in our dataset:
 species_counts <- surveys_complete %>%
-    count(species_id) %>% 
+    count(species_id) %>%
     filter(n >= 50) %>%
     select(species_id)
 

--- a/04-visualization-ggplot2.Rmd
+++ b/04-visualization-ggplot2.Rmd
@@ -2,17 +2,17 @@
 title: Data visualization with ggplot2
 author: Data Carpentry contributors
 minutes: 60
-editor_options: 
+editor_options:
   chunk_output_type: console
 ---
 
 
 ```{r setup, echo=FALSE, message = FALSE, warning = FALSE, purl=FALSE}
 source("setup.R")
-surveys_complete <- read_csv(file = "data_raw/portal_data_joined.csv", col_types = cols()) %>% 
-  drop_na(weight, hindfoot_length, sex) %>% 
-  group_by(species_id) %>% 
-  filter(n() >= 50) %>% 
+surveys_complete <- read_csv(file = "data_raw/portal_data_joined.csv", col_types = cols()) %>%
+  drop_na(weight, hindfoot_length, sex) %>%
+  group_by(species_id) %>%
+  filter(n() >= 50) %>%
   ungroup()
 ```
 
@@ -48,12 +48,12 @@ surveys_complete <- read_csv("data/surveys_complete.csv")
 
 ## Plotting with **`ggplot2`**
 
-**`ggplot2`** is a plotting package that makes it simple to create complex plots
+**`ggplot2`** is a plotting package that provides helpful commands to create complex plots
 from data in a data frame. It provides a more programmatic interface for
 specifying what variables to plot, how they are displayed, and general visual
-properties. Therefore, we only need minimal changes if the underlying data 
-change or if we decide to change from a bar plot to a scatterplot. This helps in 
-creating publication quality plots with minimal amounts of adjustments and 
+properties. Therefore, we only need minimal changes if the underlying data
+change or if we decide to change from a bar plot to a scatterplot. This helps in
+creating publication quality plots with minimal amounts of adjustments and
 tweaking.
 
 **`ggplot2`** plots work best with data in the 'long' format, i.e., a column for every variable,
@@ -69,15 +69,15 @@ To build a ggplot, we will use the following basic template that can be used for
 ggplot(data = <DATA>, mapping = aes(<MAPPINGS>)) +  <GEOM_FUNCTION>()
 ```
 
-- use the `ggplot()` function and bind the plot to a specific data frame using 
+- use the `ggplot()` function and bind the plot to a specific data frame using
   the `data` argument
 
 ```{r, eval = FALSE, purl = FALSE}
 ggplot(data = surveys_complete)
 ```
 
-- define an aesthetic mapping (using the aesthetic (`aes`) function), by 
-selecting the variables to be plotted and specifying how to present them in the 
+- define an aesthetic mapping (using the aesthetic (`aes`) function), by
+selecting the variables to be plotted and specifying how to present them in the
 graph, e.g., as x/y positions or characteristics such as size, shape, color, etc.      
 
 ```{r, eval = FALSE, purl = FALSE}
@@ -85,14 +85,14 @@ ggplot(data = surveys_complete, mapping = aes(x = weight, y = hindfoot_length))
 ```
 
 - add 'geoms' – graphical representations of the data in the plot (points,
-  lines, bars). **`ggplot2`** offers many different geoms; we will use some 
+  lines, bars). **`ggplot2`** offers many different geoms; we will use some
   common ones today, including:
-  
+
   * `geom_point()` for scatter plots, dot plots, etc.
   * `geom_boxplot()` for, well, boxplots!
   * `geom_line()` for trend lines, time series, etc.  
 
-To add a geom to the plot use `+` operator. Because we have two continuous 
+To add a geom to the plot use `+` operator. Because we have two continuous
 variables, let's use `geom_point()` first:
 
 ```{r first-ggplot, purl = FALSE}
@@ -100,40 +100,40 @@ ggplot(data = surveys_complete, aes(x = weight, y = hindfoot_length)) +
   geom_point()
 ```
 
-The `+` in the **`ggplot2`** package is particularly useful because it allows 
+The `+` in the **`ggplot2`** package is particularly useful because it allows
 you to modify existing `ggplot` objects. This means you can easily set up plot
 "templates" and conveniently explore different types of plots, so the above
 plot can also be generated with code like this:
 
 ```{r, first-ggplot-with-plus, eval = FALSE, purl = FALSE}
 # Assign plot to a variable
-surveys_plot <- ggplot(data = surveys_complete, 
+surveys_plot <- ggplot(data = surveys_complete,
                        mapping = aes(x = weight, y = hindfoot_length))
 
 # Draw the plot
-surveys_plot + 
+surveys_plot +
     geom_point()
 ```
 
 ```{r, eval = FALSE, purl = TRUE, echo = FALSE, purl = FALSE}
 ## Create a ggplot and draw it.
-surveys_plot <- ggplot(data = surveys_complete, 
+surveys_plot <- ggplot(data = surveys_complete,
                        aes(x = weight, y = hindfoot_length))
 
-surveys_plot + 
+surveys_plot +
   geom_point()
 ```
 
 **Notes**
 
 - Anything you put in the `ggplot()` function can be seen by any geom layers
-  that you add (i.e., these are universal plot settings). This includes the x- 
+  that you add (i.e., these are universal plot settings). This includes the x-
   and y-axis you set up in `aes()`.
 - You can also specify aesthetics for a given geom independently of the
   aesthetics defined globally in the `ggplot()` function.
-- The `+` sign used to add layers must be placed at the end of each line 
-  containing a layer. If, instead, the `+` sign is added in the line before the 
-  other layer, **`ggplot2`** will not add the new layer and will return an error 
+- The `+` sign used to add layers must be placed at the end of each line
+  containing a layer. If, instead, the `+` sign is added in the line before the
+  other layer, **`ggplot2`** will not add the new layer and will return an error
   message.
 - You may notice that we sometimes reference 'ggplot2' and sometimes 'ggplot'.
   To clarify, 'ggplot2' is the name of the most recent version of the package.
@@ -235,7 +235,7 @@ ggplot(data = surveys_complete, mapping = aes(x = weight, y = hindfoot_length)) 
 > Is this a good way to show this type of data?
 >
 > ```{r scatter-challenge-answer, answer=TRUE, purl=FALSE}
-> ggplot(data = surveys_complete, 
+> ggplot(data = surveys_complete,
 >        mapping = aes(x = species_id, y = weight)) +
 >    geom_point(aes(color = plot_type))
 > ```
@@ -275,7 +275,7 @@ hidden?
 >
 > Boxplots are useful summaries, but hide the *shape* of the distribution. For
 > example, if there is a bimodal distribution, it would not be observed with a
-> boxplot. An alternative to the boxplot is the violin plot (sometimes known as 
+> boxplot. An alternative to the boxplot is the violin plot (sometimes known as
 > a beanplot), where the shape (of the density of points) is drawn.
 >
 > - Replace the box plot with a violin plot; see `geom_violin()`.
@@ -297,7 +297,7 @@ hidden?
 > - Add color to the data points on your boxplot according to the plot from which
 >   the sample was taken (`plot_id`).
 
-> Hint: Check the class for `plot_id`. Consider changing the class of `plot_id` 
+> Hint: Check the class for `plot_id`. Consider changing the class of `plot_id`
 > from integer to factor. Why does this change how R makes the graph?
 
 ```{r boxplot-challenge, eval = FALSE, purl = TRUE, echo = FALSE}
@@ -332,7 +332,7 @@ yearly_counts <- surveys_complete %>%
   count(year, genus)
 ```
 
-Timelapse data can be visualized as a line plot with years on the x-axis and 
+Timelapse data can be visualized as a line plot with years on the x-axis and
 counts on the y-axis:
 
 ```{r first-time-series, purl = FALSE}
@@ -349,7 +349,7 @@ ggplot(data = yearly_counts, aes(x = year, y = n, group = genus)) +
     geom_line()
 ```
 
-We will be able to distinguish genera in the plot if we add colors (using 
+We will be able to distinguish genera in the plot if we add colors (using
 `color` also automatically groups the data):
 
 ```{r time-series-with-colors, purl = FALSE}
@@ -367,7 +367,7 @@ We can also use the pipe operator to pass the `data` argument to the
 you need to use `+` and not `%>%`.
 
 ```{r integrating-the-pipe, purl=FALSE}
-yearly_counts %>% 
+yearly_counts %>%
     ggplot(mapping = aes(x = year, y = n, color = genus)) +
     geom_line()
 ```
@@ -376,7 +376,7 @@ The pipe operator can also be used to link data manipulation with consequent dat
 
 ```{r pipes-and-manipulation, purl=FALSE}
 yearly_counts_graph <- surveys_complete %>%
-    count(year, genus) %>% 
+    count(year, genus) %>%
     ggplot(mapping = aes(x = year, y = n, color = genus)) +
     geom_line()
 
@@ -386,8 +386,8 @@ yearly_counts_graph
 
 ## Faceting
 
-`ggplot` has a special technique called *faceting* that allows the user to split 
-one plot into multiple plots based on a factor included in the dataset. We will 
+`ggplot` has a special technique called *faceting* that allows the user to split
+one plot into multiple plots based on a factor included in the dataset. We will
 use it to make a time series plot for each genus:
 
 ```{r first-facet, purl = FALSE}
@@ -405,7 +405,7 @@ measured. To do that we need to make counts in the data frame grouped by `year`,
                       count(year, genus, sex)
 ```
 
-We can now make the faceted plot by splitting further by sex using `color` 
+We can now make the faceted plot by splitting further by sex using `color`
 (within a single plot):
 
 ```{r facet-by-genus-and-sex, purl=FALSE}
@@ -414,10 +414,10 @@ ggplot(data = yearly_sex_counts, mapping = aes(x = year, y = n, color = sex)) +
   facet_wrap(facets =  vars(genus))
 ```
 
-We can also facet both by sex and genus: 
+We can also facet both by sex and genus:
 
 ```{r average-weight-time-facet-both, purl=FALSE, fig.width=9.5}
-ggplot(data = yearly_sex_counts, 
+ggplot(data = yearly_sex_counts,
        mapping = aes(x = year, y = n, color = sex)) +
   geom_line() +
   facet_grid(rows = vars(sex), cols =  vars(genus))
@@ -427,7 +427,7 @@ You can also organise the panels only by rows (or only by columns):
 
 ```{r average-weight-time-facet-sex-rows, purl=FALSE, fig.height=8.5, fig.width=8}
 # One column, facet by rows
-ggplot(data = yearly_sex_counts, 
+ggplot(data = yearly_sex_counts,
        mapping = aes(x = year, y = n, color = sex)) +
   geom_line() +
   facet_grid(rows = vars(genus))
@@ -435,14 +435,14 @@ ggplot(data = yearly_sex_counts,
 
 ```{r average-weight-time-facet-sex-columns, purl=FALSE, fig.width=9.5, fig.height=5}
 # One row, facet by column
-ggplot(data = yearly_sex_counts, 
+ggplot(data = yearly_sex_counts,
        mapping = aes(x = year, y = n, color = sex)) +
   geom_line() +
   facet_grid(cols = vars(genus))
 ```
 
 
-**Note:** 
+**Note:**
 `ggplot2` before version 3.0.0 used formulas to specify how plots are faceted.
 If you encounter `facet_grid`/`wrap(...)` code containing `~`, please read
 <https://ggplot2.tidyverse.org/news/#tidy-evaluation>.
@@ -450,16 +450,16 @@ If you encounter `facet_grid`/`wrap(...)` code containing `~`, please read
 
 ## **`ggplot2`** themes
 
-Usually plots with white background look more readable when printed. 
-Every single component of a `ggplot` graph can be customized using the generic 
-`theme()` function, as we will see below. However, there are pre-loaded themes 
-available that change the overall appearance of the graph without much effort. 
+Usually plots with white background look more readable when printed.
+Every single component of a `ggplot` graph can be customized using the generic
+`theme()` function, as we will see below. However, there are pre-loaded themes
+available that change the overall appearance of the graph without much effort.
 
-For example, we can change our previous graph to have a simpler white background 
+For example, we can change our previous graph to have a simpler white background
 using the `theme_bw()` function:
 
 ```{r facet-by-species-and-sex-white-bg, purl=FALSE}
- ggplot(data = yearly_sex_counts, 
+ ggplot(data = yearly_sex_counts,
         mapping = aes(x = year, y = n, color = sex)) +
      geom_line() +
      facet_wrap(vars(genus)) +
@@ -481,7 +481,7 @@ provides a wide variety of options.
 >
 > Use what you just learned to create a plot that depicts how the average weight
 > of each species changes through the years.
-> 
+>
 > ```{r average-weight-time-series, answer=TRUE, purl=FALSE}
 > yearly_weight <- surveys_complete %>%
 >                 group_by(year, species_id) %>%
@@ -540,7 +540,7 @@ the [**`extrafont`** package](https://github.com/wch/extrafont), and follow the
 instructions included in the README for this package.
 
 After our manipulations, you may notice that the values on the x-axis are still
-not properly readable. Let's change the orientation of the labels and adjust 
+not properly readable. Let's change the orientation of the labels and adjust
 them vertically and horizontally so they don't overlap. You can use a 90 degree
 angle, or experiment to find the appropriate angle for diagonally oriented
 labels. We can also modify the facet label text (`strip.text`) to italicize the genus
@@ -565,8 +565,8 @@ them as an object to be able to easily apply them to other plots you may create:
 
 
 ```{r number-species-year-with-right-labels-xfont-orientation, purl = FALSE}
-grey_theme <- theme(axis.text.x = element_text(colour="grey20", size = 12, 
-                                               angle = 90, hjust = 0.5, 
+grey_theme <- theme(axis.text.x = element_text(colour="grey20", size = 12,
+                                               angle = 90, hjust = 0.5,
                                                vjust = 0.5),
                     axis.text.y = element_text(colour = "grey20", size = 12),
                     text=element_text(size = 16))
@@ -580,31 +580,31 @@ ggplot(surveys_complete, aes(x = species_id, y = hindfoot_length)) +
 >
 > With all of this information in hand, please take another five minutes to either
 > improve one of the plots generated in this exercise or create a beautiful graph
-> of your own. Use the RStudio [**`ggplot2`** cheat sheet](https://www.rstudio.com/wp-content/uploads/2016/11/ggplot2-cheatsheet-2.1.pdf) 
+> of your own. Use the RStudio [**`ggplot2`** cheat sheet](https://www.rstudio.com/wp-content/uploads/2016/11/ggplot2-cheatsheet-2.1.pdf)
 > for inspiration.
 >
 > Here are some ideas:
 >
-> * See if you can change the thickness of the lines. 
+> * See if you can change the thickness of the lines.
 > * Can you find a way to change the name of the legend? What about its labels?
 > * Try using a different color palette (see
 >   <https://www.cookbook-r.com/Graphs/Colors_(ggplot2)/>).
 
 ## Arranging plots
 
-Faceting is a great tool for splitting one plot into multiple plots, but 
+Faceting is a great tool for splitting one plot into multiple plots, but
 sometimes you may want to produce a single figure that contains multiple plots
-using different variables or even different data frames. The **`patchwork`** 
+using different variables or even different data frames. The **`patchwork`**
 package allows us to combine separate ggplots into a single figure while keeping
-everything aligned properly. Like most R packages, we can install `patchwork` 
+everything aligned properly. Like most R packages, we can install `patchwork`
 from CRAN, the R package repository:
 
 ```{r patchwork-install, eval = FALSE}
 install.packages("patchwork")
 ```
 
-After you have loaded the `patchwork` package you can use `+` to place plots 
-next to each other, `/` to arrange them vertically, and `plot_layout()` to 
+After you have loaded the `patchwork` package you can use `+` to place plots
+next to each other, `/` to arrange them vertically, and `plot_layout()` to
 determine how much space each plot uses:
 
 ```{r patchwork-example, message = FALSE, purl = FALSE, fig.width = 10}
@@ -616,30 +616,30 @@ plot_weight <- ggplot(data = surveys_complete, aes(x = species_id, y = weight)) 
   scale_y_log10()
 
 plot_count <- ggplot(data = yearly_counts, aes(x = year, y = n, color = genus)) +
-  geom_line() + 
+  geom_line() +
   labs(x = "Year", y = "Abundance")
 
 plot_weight / plot_count + plot_layout(heights = c(3, 2))
 ```
 
 You can also use parentheses `()` to create more complex layouts. There are
-many useful examples on the [patchwork website](https://patchwork.data-imaginist.com/) 
+many useful examples on the [patchwork website](https://patchwork.data-imaginist.com/)
 
 ## Exporting plots
 
 After creating your plot, you can save it to a file in your favorite format. The
-Export tab in the **Plot** pane in RStudio will save your plots at low 
-resolution, which will not be accepted by many journals and will not scale well 
+Export tab in the **Plot** pane in RStudio will save your plots at low
+resolution, which will not be accepted by many journals and will not scale well
 for posters. The [**`ggplot2`** extensions website](https://exts.ggplot2.tidyverse.org/) provides a list
 of packages that extend the capabilities of **`ggplot2`**, including additional
 themes.
 
-Instead, use the `ggsave()` function, which allows you easily change the 
-dimension and resolution of your plot by adjusting the appropriate arguments 
+Instead, use the `ggsave()` function, which allows you easily change the
+dimension and resolution of your plot by adjusting the appropriate arguments
 (`width`, `height` and `dpi`):
 
 ```{r ggsave-example, eval = FALSE, purl = FALSE}
-my_plot <- ggplot(data = yearly_sex_counts, 
+my_plot <- ggplot(data = yearly_sex_counts,
                   aes(x = year, y = n, color = sex)) +
     geom_line() +
     facet_wrap(vars(genus)) +
@@ -659,7 +659,7 @@ plot_combined <- plot_weight / plot_count + plot_layout(heights = c(3, 2))
 ggsave("plot_combined.png", plot_combined, width = 10, dpi = 300)
 ```
 
-Note: The parameters `width` and `height` also determine the font size in the 
+Note: The parameters `width` and `height` also determine the font size in the
 saved plot.
 
 

--- a/05-r-and-databases.Rmd
+++ b/05-r-and-databases.Rmd
@@ -536,7 +536,7 @@ my_db
 
 If you check the location of our database you'll see that data is automatically
 being written to disk. R and **`dplyr`** not only provide ways to query
-existing databases, they also allows provide functionality to create your own databases
+existing databases, they also provide functionality to create your own databases
 from flat files!
 
 > ### Challenge

--- a/05-r-and-databases.Rmd
+++ b/05-r-and-databases.Rmd
@@ -22,8 +22,8 @@ if (file.exists("portal-database.sqlite")) file.remove("portal-database.sqlite")
 >
 > * Access a database from R.
 > * Run SQL queries in R using **`RSQLite`** and **`dplyr`**.
-> * Describe the lazy behavior of dplyr on data stored in a database outside of R. 
-> * Prototype queries and retrieve all final results. 
+> * Describe the lazy behavior of dplyr on data stored in a database outside of R.
+> * Prototype queries and retrieve all final results.
 > * Create complex queries across one or multiple database tables.
 > * Create an SQLite database from existing .csv files.
 
@@ -45,14 +45,14 @@ R can connect to almost any existing database type. Most common database types
 have R packages that allow you to connect to them (e.g., **`RSQLite`**, RMySQL,
 etc). Furthermore,
 the [**`dplyr`**](https://cran.r-project.org/web/packages/dplyr/index.html) package
-you used in the previous chapter, in conjunction with [**`dbplyr`**](https://cran.r-project.org/package=dbplyr) 
+you used in the previous chapter, in conjunction with [**`dbplyr`**](https://cran.r-project.org/package=dbplyr)
 supports connecting to the widely-used open
 source databases [sqlite](https://sqlite.org/), [mysql](https://www.mysql.com/)
 and [postgresql](https://www.postgresql.org/), as well as
 Google’s [bigquery](https://cloud.google.com/bigquery/), and it can also be
-extended to other database types (a [vignette](https://cran.r-project.org/web/packages/dbplyr/vignettes/new-backend.html) 
-in the **`dplyr`** package explains how to do it). RStudio has created 
-[a website](http://db.rstudio.com/) that provides documentation and best practices 
+extended to other database types (a [vignette](https://cran.r-project.org/web/packages/dbplyr/vignettes/new-backend.html)
+in the **`dplyr`** package explains how to do it). RStudio has created
+[a website](http://db.rstudio.com/) that provides documentation and best practices
 to work on database interfaces.
 
 Interfacing with databases using **`dplyr`** focuses on retrieving and analyzing
@@ -92,16 +92,16 @@ library(dbplyr)
 mammals <- DBI::dbConnect(RSQLite::SQLite(), "data_raw/portal_mammals.sqlite")
 ```
 
-This command uses 2 packages that helps **`dbplyr`** and **`dplyr`** talk to the 
-SQLite database. **`DBI`** is not something that you'll use directly as a user. 
-It allows R to send commands to databases irrespective of the database management 
+This command uses 2 packages that helps **`dbplyr`** and **`dplyr`** talk to the
+SQLite database. **`DBI`** is not something that you'll use directly as a user.
+It allows R to send commands to databases irrespective of the database management
 system used. The **`RSQLite`** package allows R to interface with SQLite databases.
 
 This command does not load the data into the R session (as the
 `read_csv()` function did). Instead, it merely instructs R to connect to
 the `SQLite` database contained in the `portal_mammals.sqlite` file.
 
-Using a similar approach, you could connect to many other database management 
+Using a similar approach, you could connect to many other database management
 systems that are supported by R including MySQL, PostgreSQL, BigQuery, etc.
 
 Let's take a closer look at the `mammals` database we just connected to:
@@ -342,7 +342,7 @@ records, and join the two tables.
 
 If we have two tables named x and y with a common column called "ID", we can join them using 'join' functions, two of which are described and illustrated below.
 
-1. inner_join() : This returns all rows from x where there are matching values in y, and all columns from x and y. 
+1. inner_join() : This returns all rows from x where there are matching values in y, and all columns from x and y.
 
 2. left_join() : This return all rows from x, and all columns from x and y. Rows in x with no match in y will have NA values in the new columns.  
 
@@ -392,13 +392,13 @@ retrieved.
 > ```{r left_join_answer, answer=TRUE, eval=TRUE}
 > ## with dplyr syntax
 > species <- tbl(mammals, "species")
-> 
+>
 > left_join(surveys, species) %>%
 >   filter(taxa == "Rodent") %>%
 >   group_by(taxa, year, plot_id) %>%
 >   tally() %>%
 >   collect()
-> 
+>
 > ## with SQL syntax
 > query <- paste("
 > SELECT a.year, b.taxa,count(*) as count
@@ -408,10 +408,10 @@ retrieved.
 > AND b.taxa = 'Rodent'
 > GROUP BY b.taxa, a.year, a.plot_id",
 > sep = "" )
-> 
+>
 > tbl(mammals, sql(query))
 > >
-> ``` 
+> ```
 
 
 ```{r challenge-sql-1, purl=TRUE, echo=FALSE}
@@ -443,7 +443,7 @@ retrieved.
 >
 >  Hint: Write a query that joins the species, plot, and survey tables together.
 >  The query should return counts of genus by plot type.
-> 
+>
 > ```{r genus_by_type_answer, answer=TRUE, results='markup', eval=FALSE}
 > species <- tbl(mammals, "species")
 > genus_counts <- left_join(surveys, plots) %>%
@@ -508,7 +508,7 @@ surveys <- read_csv("data_raw/surveys.csv")
 plots <- read_csv("data_raw/plots.csv")
 ```
 
-Creating a new SQLite database with **`dplyr`** is easy. You can re-use the same
+Also, you can create new SQLite database with **`dplyr`** by adding an argument to the same
 command we used above to open an existing `.sqlite` file. The `create = TRUE`
 argument instructs R to create a new, empty database instead.
 
@@ -535,8 +535,8 @@ my_db
 ```
 
 If you check the location of our database you'll see that data is automatically
-being written to disk. R and **`dplyr`** not only provide easy ways to query
-existing databases, they also allows you to easily create your own databases
+being written to disk. R and **`dplyr`** not only provide ways to query
+existing databases, they also allows provide functionality to create your own databases
 from flat files!
 
 > ### Challenge
@@ -558,8 +558,8 @@ from flat files!
 reading the three `csv` files. Because all the data has to flow through R,
 this is not suitable for very large datasets.
 
-**Note:** Finally, to close the connection to the mammals database you may use 
-`DBI::dbDisconnect(mammals)`; this discards all pending work and frees resources, 
+**Note:** Finally, to close the connection to the mammals database you may use
+`DBI::dbDisconnect(mammals)`; this discards all pending work and frees resources,
 e.g. memory.
 
 


### PR DESCRIPTION
This PR addresses issue #759. Specifically, I have tried to reword sentences using easy, easier, simple or just. With my replacement I sought to emphasize how the concepts taught help/assist learners in what they aim to do and better explain what the effect of using a specific command is to illustrate the usage. 

Occasionally, I felt that the sentences using 'easy' were redundant or didn't provide additional information. I deleted them in those cases. 

Please ignore the removed trailing whitespaces, unfortunately I didn't see those diffs before commiting. They don't have an effect on the rendered output. 