### PR TITLE
fix broken link as in issue 754

### DIFF
--- a/01-intro-to-r.Rmd
+++ b/01-intro-to-r.Rmd
@@ -52,7 +52,7 @@ weight_kg <- 55
 the left. So, after executing `x <- 3`, the value of `x` is `3`.   For historical reasons, you can also use `=`
 for assignments, but not in every context. Because of the
 [slight](https://blog.revolutionanalytics.com/2008/12/use-equals-or-arrow-for-assignment.html)
-[differences](https://r.789695.n4.nabble.com/Is-there-any-difference-between-and-tp878594p878598.html)
+[differences](https://renkun.me/2014/01/28/difference-between-assignment-operators-in-r/)
 in syntax, it is good practice to always use `<-` for assignments.
 
 In RStudio, typing <kbd>Alt</kbd> + <kbd>-</kbd> (push <kbd>Alt</kbd> at the


### PR DESCRIPTION
Replaced broken link for R syntax differences examples, as raised in issue https://github.com/datacarpentry/R-ecology-lesson/issues/754.