### PR TITLE
fixed broken link

### DIFF
--- a/00-before-we-start.Rmd
+++ b/00-before-we-start.Rmd
@@ -270,7 +270,7 @@ script (indicated by the cursor) or all of the commands in the currently
 selected text will be sent to the console and executed when you press
 <kbd>`Ctrl`</kbd> + <kbd>`Enter`</kbd>. You can find other keyboard shortcuts in
 this [RStudio cheatsheet about the RStudio
-IDE](https://github.com/rstudio/cheatsheets/raw/master/rstudio-ide.pdf).
+IDE](https://raw.githubusercontent.com/rstudio/cheatsheets/main/rstudio-ide.pdf).
 
 At some point in your analysis you may want to check the content of a variable
 or the structure of an object, without necessarily keeping a record of it in


### PR DESCRIPTION

I fixed the broken link for the Rstudio cheatsheet to the published link that works.

This new location is the location referred to as published in the original  repos readme.