### PR TITLE
[Workbench Beta] Pre-beta banner 

### DIFF
--- a/_site.yml
+++ b/_site.yml
@@ -9,5 +9,6 @@ output:
       collapsed: false
     include:
       in_header: header.html
+      before_body: before_body.html
       after_body: footer.html
     css: style.css

--- a/before_body.html
+++ b/before_body.html
@@ -1,0 +1,10 @@
+<div class="alert alert-warning life-cycle">
+  A snapshot of this lesson from 2022-10-17 is being tested on
+  <a href='https://carpentries.github.io/workbench'>The Carpentries Workbench</a>:
+  <a href="https://preview.carpentries.org/R-ecology-lesson">https://preview.carpentries.org/R-ecology-lesson</a>.
+  <br>
+  <b>The Workbench version of this lesson will become default on 2022-01-23</b>.
+  <button type="button" style="border: true; position: absolute; top: 0px; right: 50px; color: #383838;" class="close" data-dismiss="alert" aria-label="Close">
+    <span aria-hidden="true" style='font-size:34pt'>&times;</span>
+  </button>
+</div>


### PR DESCRIPTION
This adds a banner to the lesson that announces its place in the beta phase of The Workbench and points people to the snapshot at https://preview.carpentries.org/R-ecology-lesson

**Please merge this on Monday, 2022-10-17**

![screenshot of warning banner that says there is a snapshot of this lesson being tested on The Carpentries Workbench and that it will transition over in 2023](https://user-images.githubusercontent.com/3639446/195902967-71cd49a3-07f2-4e80-93ae-d0610484b18a.png)
