### PR TITLE
prevent building to gh-pages on PR; update action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,9 +26,9 @@ jobs:
           python -m pip install update-copyright
 
       - name: Setup R
-        uses: r-lib/actions/setup-r@master
+        uses: r-lib/actions/setup-r@v2
         with:
-          crayon.enabled: 'FALSE'
+          use-public-rspm: true
 
       - name: Install needed packages
         run: |
@@ -68,6 +68,7 @@ jobs:
           git add -A .
           git commit -m '[ci-skip] Deploy to GitHub Pages'
       - name: Deploy to gh-pages
+        if: github.ref == 'refs/heads/main'
         uses: ad-m/github-push-action@master
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR does two things:

1. it prevents building to gh-pages from pull requests by adding a
   control statement to the last step in the workflow
2. it make sure the workflow can run by pointing to the correct version
   in the r-lib action

This will fix #822
