### PR TITLE
replace "summarise" with "summarize" in episode 3; fix 826

### DIFF
--- a/03-dplyr.Rmd
+++ b/03-dplyr.Rmd
@@ -408,7 +408,7 @@ The `count()` function is shorthand for something we've already seen: grouping b
 ```{r, purl = FALSE}
 surveys %>%
     group_by(sex) %>%
-    summarise(count = n())
+    summarize(count = n())
 ```
 
 For convenience, `count()` provides the `sort` argument:  
@@ -543,7 +543,7 @@ the value provided.
 
 Let's use `pivot_wider()` to transform surveys to find the mean weight of each
 genus in each plot over the entire survey period. We use `filter()`,
-`group_by()` and `summarise()` to filter our observations and variables of
+`group_by()` and `summarize()` to filter our observations and variables of
 interest, and create a new variable for the `mean_weight`.
 
 ```{r, purl=FALSE}


### PR DESCRIPTION
I opted to use `summarize` as that's what the majority of the lesson uses, and most learners will be more familiar with American English. It's worth noting however that the R output however will use `summarise` as that seems to be the "true" function internally. 