### PR TITLE
update zenodo json for lesson release

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -2,400 +2,231 @@
   "contributors": [
     {
       "type": "Editor",
-      "name": "Ana Costa Conrado",
-      "orcid": "0000-0001-6345-987X"
-    },
-    {
-      "type": "Editor",
-      "name": "Auriel M.V. Fournier",
-      "orcid": "0000-0002-8530-9968"
-    },
-    {
-      "type": "Editor",
       "name": "Brian Seok",
       "orcid": "0000-0002-4513-3224"
     },
     {
       "type": "Editor",
-      "name": "Francois Michonneau",
+      "name": "François Michonneau",
       "orcid": "0000-0002-9092-966X"
+    },
+    {
+      "type": "Editor",
+      "name": "Tobias Busch",
+      "orcid": "0000-0002-8390-7892"
     }
   ],
   "creators": [
+    {
+      "name": "Brian Seok",
+      "orcid": "0000-0002-4513-3224"
+    },
     {
       "name": "François Michonneau",
       "orcid": "0000-0002-9092-966X"
     },
     {
-      "name": "Tracy Teal",
-      "orcid": "0000-0002-9180-9598"
-    },
-    {
-      "name": "Auriel Fournier",
-      "orcid": "0000-0002-8530-9968"
-    },
-    {
-      "name": "Brian Seok",
-      "orcid": "0000-0002-4513-3224"
-    },
-    {
-      "name": "Adam Obeng"
-    },
-    {
-      "name": "Aleksandra Natalia Pawlik",
-      "orcid": "0000-0001-8418-6735"
-    },
-    {
-      "name": "Ana Costa Conrado",
-      "orcid": "0000-0001-6345-987X"
-    },
-    {
-      "name": "Kara Woo",
-      "orcid": "0000-0002-5125-4188"
-    },
-    {
-      "name": "Philip Lijnzaad"
-    },
-    {
-      "name": "Ted Hart",
-      "orcid": "0000-0001-7367-7969"
-    },
-    {
-      "name": "Ethan P White",
-      "orcid": "0000-0001-6728-7745"
-    },
-    {
-      "name": "Ben Marwick",
-      "orcid": "0000-0001-7879-4531"
-    },
-    {
-      "name": "Ben Bolker",
-      "orcid": "0000-0002-2127-0443"
-    },
-    {
-      "name": "Kari L Jordan",
-      "orcid": "0000-0003-4121-2432"
-    },
-    {
-      "name": "Jaime Ashander",
-      "orcid": "0000-0002-1841-4768"
-    },
-    {
-      "name": "Harriet Dashnow",
-      "orcid": "0000-0001-8433-6270"
-    },
-    {
-      "name": "Kate Hertweck",
-      "orcid": "0000-0002-4026-4612"
-    },
-    {
-      "name": "Sergio Martínez Cuesta",
-      "orcid": "0000-0001-9806-2805"
-    },
-    {
-      "name": "Erin Alison Becker",
-      "orcid": "0000-0002-6832-0233"
-    },
-    {
-      "name": "Stéphane Guillou",
-      "orcid": "0000-0001-8992-0951"
-    },
-    {
-      "name": "Alexey Shiklomanov"
-    },
-    {
-      "name": "David Klinges",
-      "orcid": "0000-0002-7900-9379"
-    },
-    {
-      "name": "Gabriel J. Odom"
-    },
-    {
-      "name": "Jean, Martin"
-    },
-    {
-      "name": "K. A. S. Mislan"
-    },
-    {
-      "name": "Kayla Johnson"
-    },
-    {
-      "name": "Najko Jahn"
-    },
-    {
-      "name": "Sara Mannheimer"
-    },
-    {
-      "name": "Steve Pederson"
-    },
-    {
-      "name": "Alex Pletzer"
-    },
-    {
-      "name": "Anne Fouilloux",
-      "orcid": "0000-0002-1784-2920"
-    },
-    {
-      "name": "Callin Switzer",
-      "orcid": "0000-0003-0901-169X"
-    },
-    {
-      "name": "Christie Bahlai",
-      "orcid": "0000-0002-8937-8709"
-    },
-    {
-      "name": "Daijiang Li"
-    },
-    {
-      "name": "Dan Kerchner"
-    },
-    {
-      "name": "Francisco Rodriguez-Sanchez"
-    },
-    {
-      "name": "Gede Primahadi Wijaya Rajeg",
-      "orcid": "0000-0002-2047-8621"
-    },
-    {
-      "name": "Hao Ye",
-      "orcid": "0000-0002-8630-1458"
-    },
-    {
-      "name": "Hugo Tavares"
+      "name": "Tobias Busch",
+      "orcid": "0000-0002-8390-7892"
     },
     {
       "name": "Katrin Leinweber",
       "orcid": "0000-0001-5135-5758"
     },
     {
-      "name": "Kayla Peck"
+      "name": "Maneesha Sane"
     },
     {
-      "name": "Mauro Luciano Lepore",
-      "orcid": "0000-0002-1986-7988"
+      "name": "njlyon0",
+      "orcid": "0000-0003-3905-1078"
     },
     {
-      "name": "Stacey Hancock"
-    },
-    {
-      "name": "Thomas Sandmann"
-    },
-    {
-      "name": "Toby Hodges",
-      "orcid": "0000-0003-1766-456X"
-    },
-    {
-      "name": "Katrin Tirok",
-      "orcid": "0000-0002-5040-9838"
-    },
-    {
-      "name": "Martin Jean",
-      "orcid": "0000-0002-7439-1767"
-    },
-    {
-      "name": "Alistair Bailey",
-      "orcid": "0000-0003-0023-8679"
-    },
-    {
-      "name": "Achaz von Hardenberg"
-    },
-    {
-      "name": "Allison Theobold"
-    },
-    {
-      "name": "April Wright",
-      "orcid": "0000-0003-4692-3225"
-    },
-    {
-      "name": "Arindam Basu"
-    },
-    {
-      "name": "Carolina Johnson"
-    },
-    {
-      "name": "Carolyn Voter",
-      "orcid": "0000-0002-4023-7390"
-    },
-    {
-      "name": "Catherine Hulshof",
-      "orcid": "0000-0002-2200-8076"
-    },
-    {
-      "name": "Daina Bouquin"
-    },
-    {
-      "name": "Danielle Quinn"
-    },
-    {
-      "name": "Darya Vanichkina",
-      "orcid": "0000-0002-0406-164X"
-    },
-    {
-      "name": "Earle Wilson"
-    },
-    {
-      "name": "Eli Strauss"
-    },
-    {
-      "name": "Ellen Bledsoe",
-      "orcid": "0000-0002-3629-7235"
-    },
-    {
-      "name": "Emilia Gan"
-    },
-    {
-      "name": "Dmytro Fishman",
-      "orcid": "0000-0002-4644-8893"
-    },
-    {
-      "name": "Fred Boehm"
-    },
-    {
-      "name": "Gergana Daskalova",
-      "orcid": "0000-0002-5674-5322"
+      "name": "Ed Bennett",
+      "orcid": "0000-0002-1678-6701"
     },
     {
       "name": "Hugo Tavares",
       "orcid": "0000-0001-9373-2726"
     },
     {
-      "name": "Jake Kaupp",
-      "orcid": "0000-0002-3217-3294"
+      "name": "Mike Mahoney",
+      "orcid": "0000-0003-2402-304X"
     },
     {
-      "name": "Jillian Dunic",
-      "orcid": "0000-0002-0729-3083"
+      "name": "Paula Nieto",
+      "orcid": "0000-0002-0083-9901"
     },
     {
-      "name": "Jonathan Keane"
+      "name": "Susan Washko"
     },
     {
-      "name": "Joseph Stachelek",
-      "orcid": "0000-0002-5924-2464"
+      "name": "Terry Loecke"
     },
     {
-      "name": "Joshua R. Herr",
-      "orcid": "0000-0003-3425-292X"
+      "name": "Wasila Dahdul",
+      "orcid": "0000-0003-3162-7490"
     },
     {
-      "name": "Justin Millar",
-      "orcid": "0000-0002-6866-7544"
+      "name": "xli677"
     },
     {
-      "name": "Katie Lotterhos"
+      "name": "Abhijna Parigi"
     },
     {
-      "name": "Karen Cranston",
-      "orcid": "0000-0002-4798-9499"
+      "name": "Aleksander Jankowski"
     },
     {
-      "name": "Kenan Direk"
+      "name": "Allison Shay Theobold",
+      "orcid": "0000-0002-8092-6182"
     },
     {
-      "name": "Kristian Tylén",
-      "orcid": "0000-0001-7492-0078"
+      "name": "Analytics Enlightened LLC"
     },
     {
-      "name": "Kyriakos Chatzidimitriou",
-      "orcid": "0000-0003-0715-1197"
+      "name": "Anna K. Moeller",
+      "orcid": "0000-0001-9102-6959"
     },
     {
-      "name": "Lachlan Deer",
-      "orcid": "0000-0001-8646-6095"
+      "name": "Austin Rutherford"
     },
     {
-      "name": "Leszek Tarkowski"
+      "name": "Bill"
     },
     {
-      "name": "Marco Chiapello",
-      "orcid": "0000-0001-7768-3047"
+      "name": "Birgit Schmidt"
     },
     {
-      "name": "Marie-Helene Burle",
-      "orcid": "0000-0003-4853-4901"
+      "name": "Brandon Le"
     },
     {
-      "name": "Markus Ankenbrand"
+      "name": "Bridget Armstrong"
     },
     {
-      "name": "Max Czapanskiy",
-      "orcid": "0000-0002-6302-905X"
+      "name": "csoneson"
     },
     {
-      "name": "Melissa Moreno"
+      "name": "Clarke Iakovakis"
     },
     {
-      "name": "Michael Culshaw-Maurer",
-      "orcid": "0000-0003-2205-8679"
+      "name": "David Klinges",
+      "orcid": "0000-0002-7900-9379"
     },
     {
-      "name": "Michael Koontz",
-      "orcid": "0000-0002-8276-210X"
+      "name": "doujouDC",
+      "orcid": "0000-0003-4090-5587"
     },
     {
-      "name": "Michael Weisner"
+      "name": "em-bellis"
     },
     {
-      "name": "Myfanwy Johnston",
-      "orcid": "0000-0003-1212-1590"
+      "name": "Eunice Soh",
+      "orcid": "0000-0003-2405-0742"
     },
     {
-      "name": "Nick Carchedi"
+      "name": "FloHu",
+      "orcid": "0000-0001-8265-0856"
     },
     {
-      "name": "Olivia Rata Burge",
-      "orcid": "0000-0001-7719-6695"
+      "name": "Fritjof Lammers"
     },
     {
-      "name": "Paul Harrison"
+      "name": "Heili Lowman",
+      "orcid": "0000-0002-2939-9225"
     },
     {
-      "name": "Peter Humburg"
+      "name": "Jessica Ward"
     },
     {
-      "name": "Richard Pauloo",
-      "orcid": "0000-0002-6231-9530"
+      "name": "James Deaton"
     },
     {
-      "name": "Ryan Peek",
-      "orcid": "0000-0002-9577-6885"
+      "name": "Jessica Guo",
+      "orcid": "0000-0002-9566-9182"
     },
     {
-      "name": "Robin Elahi"
+      "name": "jporton"
     },
     {
-      "name": "Sandra Cortijo",
-      "orcid": "0000-0003-3291-6729"
+      "name": "Justin Shaffer",
+      "orcid": "0000-0002-9371-6336"
     },
     {
-      "name": "sfn_brt"
+      "name": "Kara Feilich"
     },
     {
-      "name": "Shivshankar Umashankar"
+      "name": "Karl Benedict",
+      "orcid": "0000-0002-9109-2072"
     },
     {
-      "name": "Shubhang Goswami",
-      "orcid": "0000-0003-0963-8003"
+      "name": "Kate Evans"
     },
     {
-      "name": "Sumedh"
+      "name": "Kevin Rue-Albrecht"
     },
     {
-      "name": "Scott Yanco",
-      "orcid": "0000-0003-4717-9370"
+      "name": "kurtshowmaker",
+      "orcid": "0000-0002-6317-9402"
     },
     {
-      "name": "Tara Webster"
+      "name": "Lisa Rosenthal"
     },
     {
-      "name": "Taylor Reiter",
-      "orcid": "0000-0002-7388-421X"
+      "name": "Maria Rivera Araya"
     },
     {
-      "name": "Will Pearse"
+      "name": "Matthew Brousil"
     },
     {
-      "name": "Ye Li"
+      "name": "Michele Mesiti"
+    },
+    {
+      "name": "Natalie Forsdick",
+      "orcid": "0000-0003-0423-3314"
+    },
+    {
+      "name": "Paula Pappalardo",
+      "orcid": "0000-0003-0853-7681"
+    },
+    {
+      "name": "Randy Johnson",
+      "orcid": "0000-0001-7754-0847"
+    },
+    {
+      "name": "Sara Tomiolo"
+    },
+    {
+      "name": "Sarah Forrester"
+    },
+    {
+      "name": "Sarah LR Stevens",
+      "orcid": "0000-0002-7040-548X"
+    },
+    {
+      "name": "Susan Gichuki"
+    },
+    {
+      "name": "Tauana Junqueira Cunha"
+    },
+    {
+      "name": "vratchaudhary"
+    },
+    {
+      "name": "Zacchaeus Compson"
+    },
+    {
+      "name": "danielkick"
+    },
+    {
+      "name": "katbeescience"
+    },
+    {
+      "name": "lidefi87"
+    },
+    {
+      "name": "tvo"
+    },
+    {
+      "name": "vmzhang"
     }
   ],
   "license": {


### PR DESCRIPTION
updating the `.zenodo.json` with metadata about contributors since last release, in preparation for the infrastructure transition.