### PR TITLE
fix link to code handout

### DIFF
--- a/episodes/00-before-we-start.Rmd
+++ b/episodes/00-before-we-start.Rmd
@@ -173,7 +173,7 @@ below.
   day (e.g., `~/data-carpentry`).
 4. Click on `Create Project`.
 5. Download the [code
-  handout](https://datacarpentry.org/R-ecology-lesson/code-handout.R), place
+  handout](files/code-handout.R), place
   it in your working directory and rename it (e.g.,
   `data-carpentry-script.R`).
 6. (Optional) Set Preferences to 'Never' save workspace in RStudio.


### PR DESCRIPTION
Coming from https://github.com/datacarpentry/R-ecology-lesson/pull/869#issuecomment-1662632569, I'm getting messages from other people that this link is broken.

This pr will fix the link in the text. 