### PR TITLE
Update slack links

### DIFF
--- a/CONTRIBUTING.Rmd
+++ b/CONTRIBUTING.Rmd
@@ -41,7 +41,7 @@ your changes as a pull request.
 
 2. Clone that repository to your own machine. (It is also possible
   to make minor edits right on GitHub.) *At your terminal:*
-  
+
   ```bash
   git clone https://github.com/your_username/R-ecology-lesson.git R-ecology-lesson
   cd R-ecology-lesson
@@ -52,14 +52,14 @@ your changes as a pull request.
   Give your branch a meaningful name,
   such as `fix-typos-dplyr-lesson`
   or `add-tutorial-on-visualization`. *At your terminal:*
-  
+
   ```bash
   git checkout -b fix-typos-dplyr-lesson
   ```
 
 4. Make your changes to the Rmd file. If you'd like to check the rendered
   version of your changes, you can do one of three things:
-  
+
   - if you have `GNU Make` installed on your system, type `make` at your shell
     terminal.
   - if you use RStudio, click on the "Knit" button in the top-right corner of
@@ -189,7 +189,7 @@ to learners.
 This is particularly useful for error prone code such as long URLs for
 downloading files.
 The code handout is created automatically from the lesson's `.Rmd` files
-by `make_code_handout.R`, and we use the `purl()` function from `knitr` to  
+by `make_code_handout.R`, and we use the `purl()` function from `knitr` to
 create the handout.
 Code that should be included in the code handout must be enclosed in an
 `R` code chunk with the chunk option `purl = TRUE` (see above).
@@ -235,6 +235,4 @@ other external resources should be included in the repository whenever possible.
 - *Where can I get help?*
   <br/>
   Mail us at [team@carpentries.org](mailto:team@carpentriesorg)
-  or come chat with us on [Slack](https://swc-slack-invite.herokuapp.com/).
-
-
+  or come chat with us on [Slack](https://slack-invite.carpentries.org/).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![Build and Deploy Website](https://github.com/datacarpentry/R-ecology-lesson/workflows/Build%20and%20Deploy%20Website/badge.svg)
-[![Create a Slack Account with us](https://img.shields.io/badge/Create_Slack_Account-The_Carpentries-071159.svg)](https://swc-slack-invite.herokuapp.com/)
-[![Slack Status](https://img.shields.io/badge/Slack_Channel-DC_Ecology_R-E01563.svg)](https://swcarpentry.slack.com/messages/C9X9EC405)
+[![Create a Slack Account with us](https://img.shields.io/badge/Create_Slack_Account-The_Carpentries-071159.svg)](https://slack-invite.carpentries.org/)
+[![Slack Status](https://img.shields.io/badge/Slack_Channel-DC_Ecology_R-E01563.svg)](https://carpentries.slack.com/messages/C9X9EC405)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.3264888.svg)](https://doi.org/10.5281/zenodo.3264888)
 
 # Data carpentry: R for data analysis and visualization of Ecological Data
@@ -52,9 +52,9 @@ If you would like to contribute, we encourage you to review our [contributing gu
 
 If you have any questions or feedback, please open an issue, contact the
 maintainers, or come chat with us on the
-[Slack Channel for this lesson](https://swcarpentry.slack.com/messages/C9X9EC405).
+[Slack Channel for this lesson](https://carpentries.slack.com/messages/C9X9EC405).
 If you don't already have a Slack account with the Carpentries, you can
-[create one](https://swc-slack-invite.herokuapp.com/).
+[create one](https://slack-invite.carpentries.org/).
 
 - Tobias Busch
 - Ana Costa Conrado

--- a/episodes/00-before-we-start.Rmd
+++ b/episodes/00-before-we-start.Rmd
@@ -100,7 +100,7 @@ aspect of your graph to visualize your data more effectively.
 
 Thousands of people use R daily. Many of them are willing to help you through
 mailing lists and websites such as [Stack Overflow](https://stackoverflow.com/),
-[RStudio community](https://community.rstudio.com/), and Slack channels such as  
+[RStudio community](https://community.rstudio.com/), and Slack channels such as
 the R for Data Science online community ([https://www.rfordatasci.com/](https://www.rfordatasci.com/)). In addition,
 there are numerous online and in person meetups organised globally through organisations
 such as R Ladies Global ([https://rladies.org/](https://rladies.org/)).


### PR DESCRIPTION
The Carpentries recently updated their Slack domain URL and invite app URL. This PR updates the links to match the new domains.