### PR TITLE
Encourage Instructors to try teaching the alternative lesson in beta

### DIFF
--- a/index.Rmd
+++ b/index.Rmd
@@ -14,6 +14,20 @@ site: sandpaper::sandpaper_site
 
 <p></p>
 
+::::::::::::::::::::::::::: instructor
+
+## Try out the alternative version of this lesson!
+[A redesigned version of this lesson](https://carpentries-incubator.github.io/R-ecology-lesson-alternative/) 
+is currently in beta testing and 
+[the Data Carpentry Ecology Curriculum Advisors are looking for feedback](https://carpentries.org/blog/2023/07/r-ecology-alt-beta/)
+from Instructors who try teaching it,
+with the aim of evaluating whether it should be adopted to replace this lesson in the official Data Carpentry Ecology curriculum.
+
+If you are planning to teach a Data Carpentry Ecology workshop, or this lesson only,
+why not try out the alternative version and let the CAC know what you think?
+
+::::::::::::::::::::::::::::::::::::::
+
 Data Carpentry's aim is to teach researchers basic concepts, skills,
 and tools for working with data so that they can get more done in less
 time, and with less pain. The lessons below were designed for those interested


### PR DESCRIPTION
Adds an Instructor Note encouraging Instructors to try teaching [the alternative version of the lesson](https://carpentries-incubator.github.io/R-ecology-lesson-alternative/) which is currently [in beta testing](https://carpentries.org/blog/2023/07/r-ecology-alt-beta/). 

The @datacarpentry/curriculum-advisors-ecology are hoping to receive more feedback from Instructors before they make a final decision on whether to adopt the new lesson into the curriculum.