### PR TITLE
Configure for Carpentries Matomo tracking

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -79,3 +79,8 @@ profiles:
 #
 # This space below is where custom yaml items (e.g. pinning
 # sandpaper and varnish versions) should live
+
+url: 'https://datacarpentry.org/R-ecology-lesson'
+analytics: carpentries
+lang: en
+


### PR DESCRIPTION
This repository was not configured for the lesson to be tracked by our web analytics. This PR updates the config to enable this, as well as filling in the missing metadata fields for lesson URL and language