### PR TITLE
Remove getting help LO from intro lesson

### DIFF
--- a/episodes/introduction-r-rstudio.Rmd
+++ b/episodes/introduction-r-rstudio.Rmd
@@ -16,7 +16,6 @@ exercises: 0
 - Understand the difference between R and RStudio
 - Describe the purpose of the different RStudio panes
 - Organize files and directories into R Projects
-- Use the RStudio help interface to get help with R functions
 - Be able to format questions to get help in the broader R community
 
 ::::::::::::::::::::::::::::::::::::::::::::::::


### PR DESCRIPTION
The content on reading help files is no longer in the "Intro to R and RStudio" lesson, so I removed the corresponding learning outcome. I am unsure if we want to add this LO to the "Exploring and understanding data" lesson where the content on help files is now located.
