### PR TITLE
Revert "Set seed at the start of the ggplot2 episode"

### DIFF
--- a/episodes/visualizing-ggplot.Rmd
+++ b/episodes/visualizing-ggplot.Rmd
@@ -29,7 +29,6 @@ exercises: 0
 
 ```{r setup, include=FALSE}
 knitr::opts_chunk$set(dpi = 200, out.height = 600, out.width = 600, R.options = list(max.print = 100))
-set.seed(20251007)
 ```
 
 We are going to be using **functions** from the **`ggplot2`** package to create visualizations of data. Functions are predefined bits of code that automate more complicated actions. R itself has many built-in functions, but we can access many more by loading other **packages** of functions and data into R.


### PR DESCRIPTION
This reverts commit cd869d05dec6333064a09e6f1bea04d67630bbe2.

Since it turns out the global seed is no longer used by geom_jitter()

Related discussion in https://github.com/datacarpentry/R-ecology-lesson/pull/942.