### PR TITLE
Added missing word

### DIFF
--- a/episodes/how-r-thinks-about-data.Rmd
+++ b/episodes/how-r-thinks-about-data.Rmd
@@ -512,7 +512,7 @@ x <- x^2
 x
 ```
 
-You will be naming a of objects in R, and there are a few common naming rules and conventions:
+You will be naming a lot of objects in R, and there are a few common naming rules and conventions:
 
 - make names clear without being too long
   - `wkg` is probably too short


### PR DESCRIPTION
Closes #974 

Adds missing word in [Assignment, objects, and values](Assignment, objects, and values) section to correct typo.

